### PR TITLE
rename startProcess to startProcessInstance

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@essential-projects/http_contracts": "^1.0.0",
     "@essential-projects/http_node": "^1.0.0",
     "@essential-projects/services": "^1.0.1",
-    "@process-engine/consumer_api_contracts": "feature~rename_start_process_to_net_specs",
+    "@process-engine/consumer_api_contracts": "^0.5.0",
     "addict-ioc": "^2.2.8",
     "async-middleware": "^1.2.1",
     "bluebird": "^3.4.7",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@essential-projects/http_contracts": "^1.0.0",
     "@essential-projects/http_node": "^1.0.0",
     "@essential-projects/services": "^1.0.1",
-    "@process-engine/consumer_api_contracts": "^0.3.0",
+    "@process-engine/consumer_api_contracts": "feature~rename_start_process_to_net_specs",
     "addict-ioc": "^2.2.8",
     "async-middleware": "^1.2.1",
     "bluebird": "^3.4.7",

--- a/src/consumer_api_client_service.ts
+++ b/src/consumer_api_client_service.ts
@@ -58,12 +58,12 @@ export class ConsumerApiClientService implements IConsumerApiService {
     return httpResponse.result;
   }
 
-  public async startProcess(context: ConsumerContext,
-                            processModelKey: string,
-                            startEventKey: string,
-                            payload: ProcessStartRequestPayload,
-                            returnOn: ProcessStartReturnOnOptions = ProcessStartReturnOnOptions.onProcessInstanceStarted,
-                          ): Promise<ProcessStartResponsePayload> {
+  public async startProcessInstance(context: ConsumerContext,
+                                    processModelKey: string,
+                                    startEventKey: string,
+                                    payload: ProcessStartRequestPayload,
+                                    returnOn: ProcessStartReturnOnOptions = ProcessStartReturnOnOptions.onProcessInstanceStarted,
+                                  ): Promise<ProcessStartResponsePayload> {
 
     if (!Object.values(ProcessStartReturnOnOptions).includes(returnOn)) {
       throw new EssentialProjectErrors.BadRequestError(`${returnOn} is not a valid return option!`);
@@ -83,11 +83,12 @@ export class ConsumerApiClientService implements IConsumerApiService {
     return httpResponse.result;
   }
 
-  public async startProcessAndAwaitEndEvent(context: ConsumerContext,
-                                            processModelKey: string,
-                                            startEventKey: string,
-                                            endEventKey: string,
-                                            payload: ProcessStartRequestPayload): Promise<ProcessStartResponsePayload> {
+  public async startProcessInstanceAndAwaitEndEvent(context: ConsumerContext,
+                                                    processModelKey: string,
+                                                    startEventKey: string,
+                                                    endEventKey: string,
+                                                    payload: ProcessStartRequestPayload,
+                                                  ): Promise<ProcessStartResponsePayload> {
 
     const url: string = restSettings.paths.startProcessAndAwaitEndEvent
       .replace(restSettings.params.processModelKey, processModelKey)

--- a/src/consumer_api_client_service.ts
+++ b/src/consumer_api_client_service.ts
@@ -10,8 +10,8 @@ import {
   ProcessModelList,
   ProcessStartRequestPayload,
   ProcessStartResponsePayload,
-  ProcessStartReturnOnOptions,
   restSettings,
+  StartCallbackType,
   UserTaskList,
   UserTaskResult,
 } from '@process-engine/consumer_api_contracts';
@@ -62,18 +62,18 @@ export class ConsumerApiClientService implements IConsumerApiService {
                                     processModelKey: string,
                                     startEventKey: string,
                                     payload: ProcessStartRequestPayload,
-                                    returnOn: ProcessStartReturnOnOptions = ProcessStartReturnOnOptions.onProcessInstanceStarted,
+                                    startCallbackType: StartCallbackType = StartCallbackType.CallbackOnProcessInstanceCreated,
                                   ): Promise<ProcessStartResponsePayload> {
 
-    if (!Object.values(ProcessStartReturnOnOptions).includes(returnOn)) {
-      throw new EssentialProjectErrors.BadRequestError(`${returnOn} is not a valid return option!`);
+    if (!Object.values(StartCallbackType).includes(startCallbackType)) {
+      throw new EssentialProjectErrors.BadRequestError(`${startCallbackType} is not a valid return option!`);
     }
 
     let url: string = restSettings.paths.startProcess
       .replace(restSettings.params.processModelKey, processModelKey)
       .replace(restSettings.params.startEventKey, startEventKey);
 
-    url = `${url}?return_on=${returnOn}`;
+    url = `${url}?start_callback_type=${startCallbackType}`;
 
     const requestAuthHeaders: IRequestOptions = this.createRequestAuthHeaders(context);
 


### PR DESCRIPTION
## What did you change?

- Rename `startProcess` to `startProcessInstance`
- Rename `startProcessAndAwaitEndEvent` to `startProcessInstanceAndAwaitEndEvent`

The method signatures now match the .NET Consumer API definitions.

## How can others test the changes?

This is a cosmetic change, so everything should work as before.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
