### PR TITLE
✨ Get instances and tasks by identity

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@essential-projects/errors_ts": "~1.4.0",
     "@essential-projects/http_contracts": "~2.3.0",
     "@essential-projects/iam_contracts": "~3.2.0",
-    "@process-engine/consumer_api_contracts": "~1.3.0",
+    "@process-engine/consumer_api_contracts": "feature~get_instances_by_owner_id",
     "async-middleware": "1.2.1",
     "bluebird": "3.5.2",
     "loggerhythm": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@essential-projects/errors_ts": "~1.4.0",
     "@essential-projects/http_contracts": "~2.3.0",
-    "@essential-projects/iam_contracts": "feature~get_instances_by_owner_id",
+    "@essential-projects/iam_contracts": "~3.3.0",
     "@process-engine/consumer_api_contracts": "feature~get_instances_by_owner_id",
     "async-middleware": "1.2.1",
     "bluebird": "3.5.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@process-engine/consumer_api_contracts": "feature~get_instances_by_owner_id",
     "async-middleware": "1.2.1",
     "bluebird": "3.5.2",
+    "jsonwebtoken": "~8.4.0",
     "loggerhythm": "3.0.3",
     "socket.io-client": "2.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@essential-projects/errors_ts": "~1.4.0",
     "@essential-projects/http_contracts": "~2.3.0",
     "@essential-projects/iam_contracts": "~3.3.0",
-    "@process-engine/consumer_api_contracts": "feature~get_instances_by_owner_id",
+    "@process-engine/consumer_api_contracts": "~2.0.0",
     "async-middleware": "1.2.1",
     "bluebird": "3.5.2",
     "jsonwebtoken": "~8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/consumer_api_client",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "the api-client package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@essential-projects/errors_ts": "~1.4.0",
     "@essential-projects/http_contracts": "~2.3.0",
-    "@essential-projects/iam_contracts": "~3.2.0",
+    "@essential-projects/iam_contracts": "feature~get_instances_by_owner_id",
     "@process-engine/consumer_api_contracts": "feature~get_instances_by_owner_id",
     "async-middleware": "1.2.1",
     "bluebird": "3.5.2",

--- a/src/accessors/external_accessor.ts
+++ b/src/accessors/external_accessor.ts
@@ -65,7 +65,7 @@ export class ExternalAccessor implements IConsumerApiAccessor {
     this._ensureIsAuthorized(requestingIdentity);
     this._socket.on(socketSettings.paths.userTaskWaiting, (message: Messages.SystemEvents.UserTaskReachedMessage) => {
 
-      const identitiesMatch: boolean = this._checkIfIdentityUserIDsMatch(requestingIdentity, message.identity);
+      const identitiesMatch: boolean = this._checkIfIdentityUserIDsMatch(requestingIdentity, message.processInstanceOwner);
       if (identitiesMatch) {
         callback(message);
       }
@@ -76,7 +76,7 @@ export class ExternalAccessor implements IConsumerApiAccessor {
     this._ensureIsAuthorized(requestingIdentity);
     this._socket.on(socketSettings.paths.userTaskFinished, (message: Messages.SystemEvents.UserTaskFinishedMessage) => {
 
-      const identitiesMatch: boolean = this._checkIfIdentityUserIDsMatch(requestingIdentity, message.identity);
+      const identitiesMatch: boolean = this._checkIfIdentityUserIDsMatch(requestingIdentity, message.processInstanceOwner);
       if (identitiesMatch) {
         callback(message);
       }
@@ -117,7 +117,7 @@ export class ExternalAccessor implements IConsumerApiAccessor {
     this._ensureIsAuthorized(requestingIdentity);
     this._socket.on(socketSettings.paths.manualTaskWaiting, (message: Messages.SystemEvents.UserTaskReachedMessage) => {
 
-      const identitiesMatch: boolean = this._checkIfIdentityUserIDsMatch(requestingIdentity, message.identity);
+      const identitiesMatch: boolean = this._checkIfIdentityUserIDsMatch(requestingIdentity, message.processInstanceOwner);
       if (identitiesMatch) {
         callback(message);
       }
@@ -128,7 +128,7 @@ export class ExternalAccessor implements IConsumerApiAccessor {
     this._ensureIsAuthorized(requestingIdentity);
     this._socket.on(socketSettings.paths.manualTaskFinished, (message: Messages.SystemEvents.ManualTaskFinishedMessage) => {
 
-      const identitiesMatch: boolean = this._checkIfIdentityUserIDsMatch(requestingIdentity, message.identity);
+      const identitiesMatch: boolean = this._checkIfIdentityUserIDsMatch(requestingIdentity, message.processInstanceOwner);
       if (identitiesMatch) {
         callback(message);
       }

--- a/src/accessors/external_accessor.ts
+++ b/src/accessors/external_accessor.ts
@@ -3,11 +3,10 @@ import * as io from 'socket.io-client';
 
 import {UnauthorizedError} from '@essential-projects/errors_ts';
 import {IHttpClient, IRequestOptions, IResponse} from '@essential-projects/http_contracts';
-import {IIdentity} from '@essential-projects/iam_contracts';
+import {IIdentity, TokenBody} from '@essential-projects/iam_contracts';
 
 import {
   CorrelationResult,
-  DecodedIdentityToken,
   EventList,
   EventTriggerPayload,
   IConsumerApiAccessor,
@@ -457,8 +456,8 @@ export class ExternalAccessor implements IConsumerApiAccessor {
 
   private _checkIfIdentityUserIDsMatch(identityA: IIdentity, identityB: IIdentity): boolean {
 
-    const decodedRequestingIdentity: DecodedIdentityToken = <DecodedIdentityToken> jsonwebtoken.decode(identityA.token);
-    const decodedUserTaskIdentity: DecodedIdentityToken = <DecodedIdentityToken> jsonwebtoken.decode(identityB.token);
+    const decodedRequestingIdentity: TokenBody = <TokenBody> jsonwebtoken.decode(identityA.token);
+    const decodedUserTaskIdentity: TokenBody = <TokenBody> jsonwebtoken.decode(identityB.token);
 
     return decodedRequestingIdentity.sub === decodedUserTaskIdentity.sub;
   }

--- a/src/accessors/external_accessor.ts
+++ b/src/accessors/external_accessor.ts
@@ -66,10 +66,7 @@ export class ExternalAccessor implements IConsumerApiAccessor {
     this._ensureIsAuthorized(requestingIdentity);
     this._socket.on(socketSettings.paths.userTaskWaiting, (message: Messages.SystemEvents.UserTaskReachedMessage) => {
 
-      const decodedRequestingIdentity: DecodedIdentityToken = <DecodedIdentityToken> jsonwebtoken.decode(requestingIdentity.token);
-      const decodedUserTaskIdentity: DecodedIdentityToken = <DecodedIdentityToken> jsonwebtoken.decode(message.identity.token);
-
-      const identitiesMatch: boolean = decodedRequestingIdentity.sub === decodedUserTaskIdentity.sub;
+      const identitiesMatch: boolean = this._checkIfIdentityUserIDsMatch(requestingIdentity, message.identity);
       if (identitiesMatch) {
         callback(message);
       }
@@ -80,10 +77,7 @@ export class ExternalAccessor implements IConsumerApiAccessor {
     this._ensureIsAuthorized(requestingIdentity);
     this._socket.on(socketSettings.paths.userTaskFinished, (message: Messages.SystemEvents.UserTaskFinishedMessage) => {
 
-      const decodedRequestingIdentity: DecodedIdentityToken = <DecodedIdentityToken> jsonwebtoken.decode(requestingIdentity.token);
-      const decodedUserTaskIdentity: DecodedIdentityToken = <DecodedIdentityToken> jsonwebtoken.decode(message.identity.token);
-
-      const identitiesMatch: boolean = decodedRequestingIdentity.sub === decodedUserTaskIdentity.sub;
+      const identitiesMatch: boolean = this._checkIfIdentityUserIDsMatch(requestingIdentity, message.identity);
       if (identitiesMatch) {
         callback(message);
       }
@@ -124,10 +118,7 @@ export class ExternalAccessor implements IConsumerApiAccessor {
     this._ensureIsAuthorized(requestingIdentity);
     this._socket.on(socketSettings.paths.manualTaskWaiting, (message: Messages.SystemEvents.UserTaskReachedMessage) => {
 
-      const decodedRequestingIdentity: DecodedIdentityToken = <DecodedIdentityToken> jsonwebtoken.decode(requestingIdentity.token);
-      const decodedUserTaskIdentity: DecodedIdentityToken = <DecodedIdentityToken> jsonwebtoken.decode(message.identity.token);
-
-      const identitiesMatch: boolean = decodedRequestingIdentity.sub === decodedUserTaskIdentity.sub;
+      const identitiesMatch: boolean = this._checkIfIdentityUserIDsMatch(requestingIdentity, message.identity);
       if (identitiesMatch) {
         callback(message);
       }
@@ -138,10 +129,7 @@ export class ExternalAccessor implements IConsumerApiAccessor {
     this._ensureIsAuthorized(requestingIdentity);
     this._socket.on(socketSettings.paths.manualTaskFinished, (message: Messages.SystemEvents.ManualTaskFinishedMessage) => {
 
-      const decodedRequestingIdentity: DecodedIdentityToken = <DecodedIdentityToken> jsonwebtoken.decode(requestingIdentity.token);
-      const decodedUserTaskIdentity: DecodedIdentityToken = <DecodedIdentityToken> jsonwebtoken.decode(message.identity.token);
-
-      const identitiesMatch: boolean = decodedRequestingIdentity.sub === decodedUserTaskIdentity.sub;
+      const identitiesMatch: boolean = this._checkIfIdentityUserIDsMatch(requestingIdentity, message.identity);
       if (identitiesMatch) {
         callback(message);
       }
@@ -465,5 +453,13 @@ export class ExternalAccessor implements IConsumerApiAccessor {
     if (noAuthTokenProvided) {
       throw new UnauthorizedError('No auth token provided!');
     }
+  }
+
+  private _checkIfIdentityUserIDsMatch(identityA: IIdentity, identityB: IIdentity): boolean {
+
+    const decodedRequestingIdentity: DecodedIdentityToken = <DecodedIdentityToken> jsonwebtoken.decode(identityA.token);
+    const decodedUserTaskIdentity: DecodedIdentityToken = <DecodedIdentityToken> jsonwebtoken.decode(identityB.token);
+
+    return decodedRequestingIdentity.sub === decodedUserTaskIdentity.sub;
   }
 }

--- a/src/accessors/external_accessor.ts
+++ b/src/accessors/external_accessor.ts
@@ -61,26 +61,28 @@ export class ExternalAccessor implements IConsumerApiAccessor {
     this._socket.on(socketSettings.paths.userTaskFinished, callback);
   }
 
-  public onUserTaskForIdentityWaiting(requestingIdentity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): void {
-    this._ensureIsAuthorized(requestingIdentity);
-    this._socket.on(socketSettings.paths.userTaskWaiting, (message: Messages.SystemEvents.UserTaskReachedMessage) => {
+  public onUserTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): void {
+    this._ensureIsAuthorized(identity);
 
-      const identitiesMatch: boolean = this._checkIfIdentityUserIDsMatch(requestingIdentity, message.processInstanceOwner);
-      if (identitiesMatch) {
-        callback(message);
-      }
-    });
+    const decodedIdentity: TokenBody = <TokenBody> jsonwebtoken.decode(identity.token);
+    const userId: string = decodedIdentity.sub;
+
+    const socketEventName: string = socketSettings.paths.userTaskForIdentityWaiting
+      .replace(socketSettings.pathParams.userId, userId);
+
+    this._socket.on(socketEventName, callback);
   }
 
-  public onUserTaskForIdentityFinished(requestingIdentity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): void {
-    this._ensureIsAuthorized(requestingIdentity);
-    this._socket.on(socketSettings.paths.userTaskFinished, (message: Messages.SystemEvents.UserTaskFinishedMessage) => {
+  public onUserTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): void {
+    this._ensureIsAuthorized(identity);
 
-      const identitiesMatch: boolean = this._checkIfIdentityUserIDsMatch(requestingIdentity, message.processInstanceOwner);
-      if (identitiesMatch) {
-        callback(message);
-      }
-    });
+    const decodedIdentity: TokenBody = <TokenBody> jsonwebtoken.decode(identity.token);
+    const userId: string = decodedIdentity.sub;
+
+    const socketEventName: string = socketSettings.paths.userTaskForIdentityFinished
+      .replace(socketSettings.pathParams.userId, userId);
+
+    this._socket.on(socketEventName, callback);
   }
 
   public onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): void {
@@ -113,26 +115,28 @@ export class ExternalAccessor implements IConsumerApiAccessor {
     this._socket.on(socketSettings.paths.manualTaskFinished, callback);
   }
 
-  public onManualTaskForIdentityWaiting(requestingIdentity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): void {
-    this._ensureIsAuthorized(requestingIdentity);
-    this._socket.on(socketSettings.paths.manualTaskWaiting, (message: Messages.SystemEvents.UserTaskReachedMessage) => {
+  public onManualTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): void {
+    this._ensureIsAuthorized(identity);
 
-      const identitiesMatch: boolean = this._checkIfIdentityUserIDsMatch(requestingIdentity, message.processInstanceOwner);
-      if (identitiesMatch) {
-        callback(message);
-      }
-    });
+    const decodedIdentity: TokenBody = <TokenBody> jsonwebtoken.decode(identity.token);
+    const userId: string = decodedIdentity.sub;
+
+    const socketEventName: string = socketSettings.paths.manualTaskForIdentityWaiting
+      .replace(socketSettings.pathParams.userId, userId);
+
+    this._socket.on(socketEventName, callback);
   }
 
-  public onManualTaskForIdentityFinished(requestingIdentity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): void {
-    this._ensureIsAuthorized(requestingIdentity);
-    this._socket.on(socketSettings.paths.manualTaskFinished, (message: Messages.SystemEvents.ManualTaskFinishedMessage) => {
+  public onManualTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): void {
+    this._ensureIsAuthorized(identity);
 
-      const identitiesMatch: boolean = this._checkIfIdentityUserIDsMatch(requestingIdentity, message.processInstanceOwner);
-      if (identitiesMatch) {
-        callback(message);
-      }
-    });
+    const decodedIdentity: TokenBody = <TokenBody> jsonwebtoken.decode(identity.token);
+    const userId: string = decodedIdentity.sub;
+
+    const socketEventName: string = socketSettings.paths.manualTaskForIdentityFinished
+      .replace(socketSettings.pathParams.userId, userId);
+
+    this._socket.on(socketEventName, callback);
   }
 
   public onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): void {
@@ -452,13 +456,5 @@ export class ExternalAccessor implements IConsumerApiAccessor {
     if (noAuthTokenProvided) {
       throw new UnauthorizedError('No auth token provided!');
     }
-  }
-
-  private _checkIfIdentityUserIDsMatch(identityA: IIdentity, identityB: IIdentity): boolean {
-
-    const decodedRequestingIdentity: TokenBody = <TokenBody> jsonwebtoken.decode(identityA.token);
-    const decodedUserTaskIdentity: TokenBody = <TokenBody> jsonwebtoken.decode(identityB.token);
-
-    return decodedRequestingIdentity.sub === decodedUserTaskIdentity.sub;
   }
 }

--- a/src/accessors/internal_accessor.ts
+++ b/src/accessors/internal_accessor.ts
@@ -8,6 +8,7 @@ import {
   IConsumerApiAccessor,
   ManualTaskList,
   Messages,
+  ProcessInstance,
   ProcessModel,
   ProcessModelList,
   ProcessStartRequestPayload,
@@ -27,6 +28,7 @@ export class InternalAccessor implements IConsumerApiAccessor {
     this._consumerApiService = consumerApiService;
   }
 
+  // Notifications
   public onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): void {
     this._ensureIsAuthorized(identity);
     this._consumerApiService.onUserTaskWaiting(identity, callback);
@@ -35,6 +37,16 @@ export class InternalAccessor implements IConsumerApiAccessor {
   public onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): void {
     this._ensureIsAuthorized(identity);
     this._consumerApiService.onUserTaskFinished(identity, callback);
+  }
+
+  public onUserTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): void {
+    this._ensureIsAuthorized(identity);
+    this._consumerApiService.onUserTaskForIdentityWaiting(identity, callback);
+  }
+
+  public onUserTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): void {
+    this._ensureIsAuthorized(identity);
+    this._consumerApiService.onUserTaskForIdentityFinished(identity, callback);
   }
 
   public onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): void {
@@ -47,16 +59,24 @@ export class InternalAccessor implements IConsumerApiAccessor {
     this._consumerApiService.onManualTaskFinished(identity, callback);
   }
 
+  public onManualTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): void {
+    this._ensureIsAuthorized(identity);
+    this._consumerApiService.onManualTaskForIdentityWaiting(identity, callback);
+  }
+
+  public onManualTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): void {
+    this._ensureIsAuthorized(identity);
+    this._consumerApiService.onManualTaskForIdentityFinished(identity, callback);
+  }
+
   public onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): void {
     this._ensureIsAuthorized(identity);
     this._consumerApiService.onProcessStarted(identity, callback);
   }
 
-  public onProcessWithProcessModelIdStarted(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnProcessStartedCallback,
-    processModelId: string,
-  ): void {
+  public onProcessWithProcessModelIdStarted(identity: IIdentity,
+                                            callback: Messages.CallbackTypes.OnProcessStartedCallback,
+                                            processModelId: string): void {
     this._ensureIsAuthorized(identity);
     this._consumerApiService.onProcessWithProcessModelIdStarted(identity, callback, processModelId);
   }
@@ -71,6 +91,7 @@ export class InternalAccessor implements IConsumerApiAccessor {
     this._consumerApiService.onProcessEnded(identity, callback);
   }
 
+  // Process models and instances
   public async getProcessModels(identity: IIdentity): Promise<ProcessModelList> {
 
     this._ensureIsAuthorized(identity);
@@ -107,37 +128,38 @@ export class InternalAccessor implements IConsumerApiAccessor {
     return this._consumerApiService.getProcessResultForCorrelation(identity, correlationId, processModelId);
   }
 
+  public async getProcessInstancesByIdentity(identity: IIdentity): Promise<Array<ProcessInstance>> {
+    this._ensureIsAuthorized(identity);
+
+    return this._consumerApiService.getProcessInstancesByIdentity(identity);
+  }
+
   // Events
   public async getEventsForProcessModel(identity: IIdentity, processModelId: string): Promise<EventList> {
-
     this._ensureIsAuthorized(identity);
 
     return this._consumerApiService.getEventsForProcessModel(identity, processModelId);
   }
 
   public async getEventsForCorrelation(identity: IIdentity, correlationId: string): Promise<EventList> {
-
     this._ensureIsAuthorized(identity);
 
     return this._consumerApiService.getEventsForCorrelation(identity, correlationId);
   }
 
   public async getEventsForProcessModelInCorrelation(identity: IIdentity, processModelId: string, correlationId: string): Promise<EventList> {
-
     this._ensureIsAuthorized(identity);
 
     return this._consumerApiService.getEventsForProcessModelInCorrelation(identity, processModelId, correlationId);
   }
 
   public async triggerMessageEvent(identity: IIdentity, messageName: string, payload?: EventTriggerPayload): Promise<void> {
-
     this._ensureIsAuthorized(identity);
 
     return this._consumerApiService.triggerMessageEvent(identity, messageName, payload);
   }
 
   public async triggerSignalEvent(identity: IIdentity, signalName: string, payload?: EventTriggerPayload): Promise<void> {
-
     this._ensureIsAuthorized(identity);
 
     return this._consumerApiService.triggerSignalEvent(identity, signalName, payload);
@@ -145,14 +167,12 @@ export class InternalAccessor implements IConsumerApiAccessor {
 
   // UserTasks
   public async getUserTasksForProcessModel(identity: IIdentity, processModelId: string): Promise<UserTaskList> {
-
     this._ensureIsAuthorized(identity);
 
     return this._consumerApiService.getUserTasksForProcessModel(identity, processModelId);
   }
 
   public async getUserTasksForCorrelation(identity: IIdentity, correlationId: string): Promise<UserTaskList> {
-
     this._ensureIsAuthorized(identity);
 
     return this._consumerApiService.getUserTasksForCorrelation(identity, correlationId);
@@ -161,10 +181,15 @@ export class InternalAccessor implements IConsumerApiAccessor {
   public async getUserTasksForProcessModelInCorrelation(identity: IIdentity,
                                                         processModelId: string,
                                                         correlationId: string): Promise<UserTaskList> {
-
     this._ensureIsAuthorized(identity);
 
     return this._consumerApiService.getUserTasksForProcessModelInCorrelation(identity, processModelId, correlationId);
+  }
+
+  public async getWaitingUserTasksByIdentity(identity: IIdentity): Promise<UserTaskList> {
+    this._ensureIsAuthorized(identity);
+
+    return this._consumerApiService.getWaitingUserTasksByIdentity(identity);
   }
 
   public async finishUserTask(identity: IIdentity,
@@ -172,7 +197,6 @@ export class InternalAccessor implements IConsumerApiAccessor {
                               correlationId: string,
                               userTaskInstanceId: string,
                               userTaskResult: UserTaskResult): Promise<void> {
-
     this._ensureIsAuthorized(identity);
 
     return this._consumerApiService.finishUserTask(identity, processInstanceId, correlationId, userTaskInstanceId, userTaskResult);
@@ -180,14 +204,12 @@ export class InternalAccessor implements IConsumerApiAccessor {
 
   // ManualTasks
   public async getManualTasksForProcessModel(identity: IIdentity, processModelId: string): Promise<ManualTaskList> {
-
     this._ensureIsAuthorized(identity);
 
     return this._consumerApiService.getManualTasksForProcessModel(identity, processModelId);
   }
 
   public async getManualTasksForCorrelation(identity: IIdentity, correlationId: string): Promise<ManualTaskList> {
-
     this._ensureIsAuthorized(identity);
 
     return this._consumerApiService.getManualTasksForCorrelation(identity, correlationId);
@@ -196,17 +218,21 @@ export class InternalAccessor implements IConsumerApiAccessor {
   public async getManualTasksForProcessModelInCorrelation(identity: IIdentity,
                                                           processModelId: string,
                                                           correlationId: string): Promise<ManualTaskList> {
-
     this._ensureIsAuthorized(identity);
 
     return this._consumerApiService.getManualTasksForProcessModelInCorrelation(identity, processModelId, correlationId);
+  }
+
+  public async getWaitingManualTasksByIdentity(identity: IIdentity): Promise<ManualTaskList> {
+    this._ensureIsAuthorized(identity);
+
+    return this._consumerApiService.getWaitingManualTasksByIdentity(identity);
   }
 
   public async finishManualTask(identity: IIdentity,
                                 processInstanceId: string,
                                 correlationId: string,
                                 manualTaskInstanceId: string): Promise<void> {
-
     this._ensureIsAuthorized(identity);
 
     return this._consumerApiService.finishManualTask(identity, processInstanceId, correlationId, manualTaskInstanceId);

--- a/src/consumer_api_client_service.ts
+++ b/src/consumer_api_client_service.ts
@@ -9,6 +9,7 @@ import {
   IConsumerApiAccessor,
   ManualTaskList,
   Messages,
+  ProcessInstance,
   ProcessModel,
   ProcessModelList,
   ProcessStartRequestPayload,
@@ -26,12 +27,21 @@ export class ConsumerApiClientService implements IConsumerApi {
     this.consumerApiAccessor = consumerApiAccessor;
   }
 
+  // Notifications
   public onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): void {
     this.consumerApiAccessor.onUserTaskWaiting(identity, callback);
   }
 
   public onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): void {
     this.consumerApiAccessor.onUserTaskFinished(identity, callback);
+  }
+
+  public onUserTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): void {
+    this.consumerApiAccessor.onUserTaskForIdentityWaiting(identity, callback);
+  }
+
+  public onUserTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): void {
+    this.consumerApiAccessor.onUserTaskForIdentityFinished(identity, callback);
   }
 
   public onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): void {
@@ -42,11 +52,9 @@ export class ConsumerApiClientService implements IConsumerApi {
     this.consumerApiAccessor.onProcessStarted(identity, callback);
   }
 
-  public onProcessWithProcessModelIdStarted(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnProcessStartedCallback,
-    processModelId: string,
-  ): void {
+  public onProcessWithProcessModelIdStarted(identity: IIdentity,
+                                            callback: Messages.CallbackTypes.OnProcessStartedCallback,
+                                            processModelId: string): void {
     this.consumerApiAccessor.onProcessWithProcessModelIdStarted(identity, callback, processModelId);
   }
 
@@ -58,17 +66,24 @@ export class ConsumerApiClientService implements IConsumerApi {
     this.consumerApiAccessor.onManualTaskFinished(identity, callback);
   }
 
+  public onManualTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): void {
+    this.consumerApiAccessor.onManualTaskForIdentityWaiting(identity, callback);
+  }
+
+  public onManualTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): void {
+    this.consumerApiAccessor.onManualTaskForIdentityFinished(identity, callback);
+  }
+
   public onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): void {
     this.consumerApiAccessor.onProcessEnded(identity, callback);
   }
 
+  // Process models and instances
   public async getProcessModels(identity: IIdentity): Promise<ProcessModelList> {
-
     return this.consumerApiAccessor.getProcessModels(identity);
   }
 
   public async getProcessModelById(identity: IIdentity, processModelId: string): Promise<ProcessModel> {
-
     return this.consumerApiAccessor.getProcessModelById(identity, processModelId);
   }
 
@@ -98,40 +113,37 @@ export class ConsumerApiClientService implements IConsumerApi {
     return this.consumerApiAccessor.getProcessResultForCorrelation(identity, correlationId, processModelId);
   }
 
+  public async getProcessInstancesByIdentity(identity: IIdentity): Promise<Array<ProcessInstance>> {
+    return this.consumerApiAccessor.getProcessInstancesByIdentity(identity);
+  }
+
   // Events
   public async getEventsForProcessModel(identity: IIdentity, processModelId: string): Promise<EventList> {
-
     return this.consumerApiAccessor.getEventsForProcessModel(identity, processModelId);
   }
 
   public async getEventsForCorrelation(identity: IIdentity, correlationId: string): Promise<EventList> {
-
     return this.consumerApiAccessor.getEventsForCorrelation(identity, correlationId);
   }
 
   public async getEventsForProcessModelInCorrelation(identity: IIdentity, processModelId: string, correlationId: string): Promise<EventList> {
-
     return this.consumerApiAccessor.getEventsForProcessModelInCorrelation(identity, processModelId, correlationId);
   }
 
   public async triggerMessageEvent(identity: IIdentity, messageName: string, payload?: EventTriggerPayload): Promise<void> {
-
     return this.consumerApiAccessor.triggerMessageEvent(identity, messageName, payload);
   }
 
   public async triggerSignalEvent(identity: IIdentity, signalName: string, payload?: EventTriggerPayload): Promise<void> {
-
     return this.consumerApiAccessor.triggerSignalEvent(identity, signalName, payload);
   }
 
   // UserTasks
   public async getUserTasksForProcessModel(identity: IIdentity, processModelId: string): Promise<UserTaskList> {
-
     return this.consumerApiAccessor.getUserTasksForProcessModel(identity, processModelId);
   }
 
   public async getUserTasksForCorrelation(identity: IIdentity, correlationId: string): Promise<UserTaskList> {
-
     return this.consumerApiAccessor.getUserTasksForCorrelation(identity, correlationId);
   }
 
@@ -140,6 +152,10 @@ export class ConsumerApiClientService implements IConsumerApi {
                                                         correlationId: string): Promise<UserTaskList> {
 
     return this.consumerApiAccessor.getUserTasksForProcessModelInCorrelation(identity, processModelId, correlationId);
+  }
+
+  public async getWaitingUserTasksByIdentity(identity: IIdentity): Promise<UserTaskList> {
+    return this.consumerApiAccessor.getWaitingUserTasksByIdentity(identity);
   }
 
   public async finishUserTask(identity: IIdentity,
@@ -153,23 +169,22 @@ export class ConsumerApiClientService implements IConsumerApi {
 
   // ManualTasks
   public async getManualTasksForProcessModel(identity: IIdentity, processModelId: string): Promise<ManualTaskList> {
-
-    return this.consumerApiAccessor
-               .getManualTasksForProcessModel(identity, processModelId);
+    return this.consumerApiAccessor.getManualTasksForProcessModel(identity, processModelId);
   }
 
   public async getManualTasksForCorrelation(identity: IIdentity, correlationId: string): Promise<ManualTaskList> {
-
-    return this.consumerApiAccessor
-               .getManualTasksForCorrelation(identity, correlationId);
+    return this.consumerApiAccessor.getManualTasksForCorrelation(identity, correlationId);
   }
 
   public async getManualTasksForProcessModelInCorrelation(identity: IIdentity,
                                                           processModelId: string,
                                                           correlationId: string): Promise<ManualTaskList> {
 
-    return this.consumerApiAccessor
-               .getManualTasksForProcessModelInCorrelation(identity, processModelId, correlationId);
+    return this.consumerApiAccessor.getManualTasksForProcessModelInCorrelation(identity, processModelId, correlationId);
+  }
+
+  public async getWaitingManualTasksByIdentity(identity: IIdentity): Promise<ManualTaskList> {
+    return this.consumerApiAccessor.getWaitingManualTasksByIdentity(identity);
   }
 
   public async finishManualTask(identity: IIdentity,
@@ -177,7 +192,6 @@ export class ConsumerApiClientService implements IConsumerApi {
                                 correlationId: string,
                                 manualTaskInstanceId: string): Promise<void> {
 
-  return this.consumerApiAccessor
-               .finishManualTask(identity, processInstanceId, correlationId, manualTaskInstanceId);
+  return this.consumerApiAccessor.finishManualTask(identity, processInstanceId, correlationId, manualTaskInstanceId);
   }
 }


### PR DESCRIPTION
**Changes:**

1. Add the following UseCases to the service and its accessors:
    - `getProcessInstancesByIdentity`
    - `getWaitingUserTasksByIdentity`
    - `getWaitingManualTasksByIdentity`
2. Add the following notification subscriptions:
    - `onManualTaskForIdentityWaiting`
    - `onManualTaskForIdentityFinished`
    - `onUserTaskForIdentityWaiting`
    - `onUserTaskForIdentityFinished`


**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/198

PR: #22

## How can others test the changes?

- Use the new UseCases to get identity-specific Tasks or ProcessInstances.
- Subscribe to the new Notifications to get identity-specific notifications about UserTasks and ManualTasks.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).