### PR TITLE
♻️ Refactor socket io handling

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -25,7 +25,6 @@
     "@process-engine/consumer_api_contracts": "feature~refactor_socket_io_handling",
     "async-middleware": "~1.2.1",
     "bluebird": "~3.5.3",
-    "jsonwebtoken": "~8.4.0",
     "loggerhythm": "^3.0.3",
     "socket.io-client": "~2.2.0"
   },

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@essential-projects/errors_ts": "~1.4.0",
     "@essential-projects/http_contracts": "~2.3.0",
-    "@essential-projects/iam_contracts": "feature~refactor_socket_io_handling",
+    "@essential-projects/iam_contracts": "~3.4.0",
     "@process-engine/consumer_api_contracts": "feature~refactor_socket_io_handling",
     "async-middleware": "~1.2.1",
     "bluebird": "~3.5.3",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "@essential-projects/errors_ts": "~1.4.0",
     "@essential-projects/http_contracts": "~2.3.0",
-    "@essential-projects/iam_contracts": "~3.3.0",
-    "@process-engine/consumer_api_contracts": "~3.0.0",
+    "@essential-projects/iam_contracts": "feature~refactor_socket_io_handling",
+    "@process-engine/consumer_api_contracts": "feature~refactor_socket_io_handling",
     "async-middleware": "~1.2.1",
     "bluebird": "~3.5.3",
     "jsonwebtoken": "~8.4.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/consumer_api_client",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "the api-client package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -22,7 +22,7 @@
     "@essential-projects/errors_ts": "~1.4.0",
     "@essential-projects/http_contracts": "~2.3.0",
     "@essential-projects/iam_contracts": "~3.4.0",
-    "@process-engine/consumer_api_contracts": "feature~refactor_socket_io_handling",
+    "@process-engine/consumer_api_contracts": "~4.0.0",
     "async-middleware": "~1.2.1",
     "bluebird": "~3.5.3",
     "loggerhythm": "^3.0.3",

--- a/typescript/src/accessors/external_accessor.ts
+++ b/typescript/src/accessors/external_accessor.ts
@@ -10,6 +10,7 @@ import {IIdentity} from '@essential-projects/iam_contracts';
 import {
   DataModels,
   IConsumerApiAccessor,
+  IConsumerSocketIoAccessor,
   Messages,
   restSettings,
   socketSettings,
@@ -22,7 +23,7 @@ import {
  */
 type SubscriptionCallbackAssociation = {[subscriptionId: string]: any};
 
-export class ExternalAccessor implements IConsumerApiAccessor {
+export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIoAccessor {
   private baseUrl: string = 'api/consumer/v1';
 
   private _subscriptionCollection: SubscriptionCallbackAssociation = {};

--- a/typescript/src/accessors/external_accessor.ts
+++ b/typescript/src/accessors/external_accessor.ts
@@ -40,6 +40,11 @@ export class ExternalAccessor implements IConsumerApiAccessor {
     this._socket = io(socketUrl, socketIoOptions);
   }
 
+  public disconnectSocket(identity: IIdentity): void {
+    this._socket.disconnect();
+    this._socket.close();
+  }
+
   // Notifications
   public async onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<any> {
     this._ensureIsAuthorized(identity);

--- a/typescript/src/accessors/external_accessor.ts
+++ b/typescript/src/accessors/external_accessor.ts
@@ -548,9 +548,9 @@ export class ExternalAccessor implements IConsumerApiAccessor {
   private _createSocketIoSubscription(route: string, callback: any, subscribeOnce: boolean): Subscription {
 
     if (subscribeOnce) {
-      this._socket.once(socketSettings.paths.userTaskFinished, callback);
+      this._socket.once(route, callback);
     } else {
-      this._socket.on(socketSettings.paths.userTaskFinished, callback);
+      this._socket.on(route, callback);
     }
 
     const subscriptionId: string = uuid.v4();

--- a/typescript/src/accessors/external_accessor.ts
+++ b/typescript/src/accessors/external_accessor.ts
@@ -182,7 +182,7 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
       return;
     }
 
-    this._socket.off(subscription.id, callbackToRemove);
+    this._socket.off(subscription.eventName, callbackToRemove);
 
     delete this._subscriptionCollection[subscription.id];
 

--- a/typescript/src/accessors/external_accessor.ts
+++ b/typescript/src/accessors/external_accessor.ts
@@ -37,6 +37,9 @@ export class ExternalAccessor implements IConsumerApiAccessor {
   }
 
   public initializeSocket(identity: IIdentity): void {
+
+    this._ensureIsAuthorized(identity);
+
     const socketUrl: string = `${this.config.socketUrl}/${socketSettings.namespace}`;
     const socketIoOptions: SocketIOClient.ConnectOpts = {
       transportOptions: {

--- a/typescript/src/accessors/external_accessor.ts
+++ b/typescript/src/accessors/external_accessor.ts
@@ -136,6 +136,12 @@ export class ExternalAccessor implements IConsumerApiAccessor {
     this._socket.on(socketSettings.paths.processEnded, callback); // TODO
   }
 
+  public async removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void> {
+    this._ensureIsAuthorized(identity);
+
+    return Promise.resolve(); // TODO
+  }
+
   // Process models and instances
   public async getProcessModels(identity: IIdentity): Promise<DataModels.ProcessModels.ProcessModelList> {
     const requestAuthHeaders: IRequestOptions = this._createRequestAuthHeaders(identity);

--- a/typescript/src/accessors/external_accessor.ts
+++ b/typescript/src/accessors/external_accessor.ts
@@ -39,7 +39,10 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
 
   public initializeSocket(identity: IIdentity): void {
 
-    this._ensureIsAuthorized(identity);
+    const noAuthTokenProvided: boolean = !identity || typeof identity.token !== 'string';
+    if (noAuthTokenProvided) {
+      throw new UnauthorizedError('No auth token provided!');
+    }
 
     const socketUrl: string = `${this.config.socketUrl}/${socketSettings.namespace}`;
     const socketIoOptions: SocketIOClient.ConnectOpts = {
@@ -65,8 +68,6 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
     subscribeOnce: boolean = false,
   ): Promise<any> {
-    this._ensureIsAuthorized(identity);
-
     return this._createSocketIoSubscription(socketSettings.paths.userTaskWaiting, callback, subscribeOnce);
   }
 
@@ -75,8 +76,6 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
     subscribeOnce: boolean = false,
   ): Promise<any> {
-    this._ensureIsAuthorized(identity);
-
     return this._createSocketIoSubscription(socketSettings.paths.userTaskFinished, callback, subscribeOnce);
   }
 
@@ -85,8 +84,6 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
     subscribeOnce: boolean = false,
   ): Promise<any> {
-    this._ensureIsAuthorized(identity);
-
     const socketEventName: string = socketSettings.paths.userTaskForIdentityWaiting
       .replace(socketSettings.pathParams.userId, identity.userId);
 
@@ -98,8 +95,6 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
     subscribeOnce: boolean = false,
   ): Promise<any> {
-    this._ensureIsAuthorized(identity);
-
     const socketEventName: string = socketSettings.paths.userTaskForIdentityFinished
       .replace(socketSettings.pathParams.userId, identity.userId);
 
@@ -111,8 +106,6 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     callback: Messages.CallbackTypes.OnProcessTerminatedCallback,
     subscribeOnce: boolean = false,
   ): Promise<any> {
-    this._ensureIsAuthorized(identity);
-
     return this._createSocketIoSubscription(socketSettings.paths.processTerminated, callback, subscribeOnce);
   }
 
@@ -121,8 +114,6 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     callback: Messages.CallbackTypes.OnProcessStartedCallback,
     subscribeOnce: boolean = false,
   ): Promise<any> {
-    this._ensureIsAuthorized(identity);
-
     return this._createSocketIoSubscription(socketSettings.paths.processStarted, callback, subscribeOnce);
   }
 
@@ -132,7 +123,6 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     processModelId: string,
     subscribeOnce: boolean = false,
   ): Promise<any> {
-    this._ensureIsAuthorized(identity);
     const eventName: string = socketSettings.paths.processInstanceStarted
       .replace(socketSettings.pathParams.processModelId, processModelId);
 
@@ -144,8 +134,6 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
     subscribeOnce: boolean = false,
   ): Promise<any> {
-    this._ensureIsAuthorized(identity);
-
     return this._createSocketIoSubscription(socketSettings.paths.manualTaskWaiting, callback, subscribeOnce);
   }
 
@@ -154,8 +142,6 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
     subscribeOnce: boolean = false,
   ): Promise<any> {
-    this._ensureIsAuthorized(identity);
-
     return this._createSocketIoSubscription(socketSettings.paths.manualTaskFinished, callback, subscribeOnce);
   }
 
@@ -164,8 +150,6 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
     subscribeOnce: boolean = false,
   ): Promise<any> {
-    this._ensureIsAuthorized(identity);
-
     const socketEventName: string = socketSettings.paths.manualTaskForIdentityWaiting
       .replace(socketSettings.pathParams.userId, identity.userId);
 
@@ -177,8 +161,6 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
     subscribeOnce: boolean = false,
   ): Promise<any> {
-    this._ensureIsAuthorized(identity);
-
     const socketEventName: string = socketSettings.paths.manualTaskForIdentityFinished
       .replace(socketSettings.pathParams.userId, identity.userId);
 
@@ -190,14 +172,10 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     callback: Messages.CallbackTypes.OnProcessEndedCallback,
     subscribeOnce: boolean = false,
   ): Promise<any> {
-    this._ensureIsAuthorized(identity);
-
     return this._createSocketIoSubscription(socketSettings.paths.processEnded, callback, subscribeOnce);
   }
 
   public async removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void> {
-    this._ensureIsAuthorized(identity);
-
     const callbackToRemove: any = this._subscriptionCollection[subscription.id];
 
     if (!callbackToRemove) {
@@ -537,13 +515,6 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
 
   private _applyBaseUrl(url: string): string {
     return `${this.baseUrl}${url}`;
-  }
-
-  private _ensureIsAuthorized(identity: IIdentity): void {
-    const noAuthTokenProvided: boolean = !identity || typeof identity.token !== 'string';
-    if (noAuthTokenProvided) {
-      throw new UnauthorizedError('No auth token provided!');
-    }
   }
 
   private _createSocketIoSubscription(route: string, callback: any, subscribeOnce: boolean): Subscription {

--- a/typescript/src/accessors/external_accessor.ts
+++ b/typescript/src/accessors/external_accessor.ts
@@ -2,6 +2,7 @@ import * as jsonwebtoken from 'jsonwebtoken';
 import * as io from 'socket.io-client';
 
 import {UnauthorizedError} from '@essential-projects/errors_ts';
+import {Subscription} from '@essential-projects/event_aggregator_contracts';
 import {IHttpClient, IRequestOptions, IResponse} from '@essential-projects/http_contracts';
 import {IIdentity, TokenBody} from '@essential-projects/iam_contracts';
 
@@ -40,17 +41,17 @@ export class ExternalAccessor implements IConsumerApiAccessor {
   }
 
   // Notifications
-  public onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): void {
+  public async onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<any> {
     this._ensureIsAuthorized(identity);
-    this._socket.on(socketSettings.paths.userTaskWaiting, callback);
+    this._socket.on(socketSettings.paths.userTaskWaiting, callback); // TODO
   }
 
-  public onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): void {
+  public async onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Promise<any> {
     this._ensureIsAuthorized(identity);
-    this._socket.on(socketSettings.paths.userTaskFinished, callback);
+    this._socket.on(socketSettings.paths.userTaskFinished, callback); // TODO
   }
 
-  public onUserTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): void {
+  public async onUserTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<any> {
     this._ensureIsAuthorized(identity);
 
     const decodedIdentity: TokenBody = <TokenBody> jsonwebtoken.decode(identity.token);
@@ -59,10 +60,10 @@ export class ExternalAccessor implements IConsumerApiAccessor {
     const socketEventName: string = socketSettings.paths.userTaskForIdentityWaiting
       .replace(socketSettings.pathParams.userId, userId);
 
-    this._socket.on(socketEventName, callback);
+    this._socket.on(socketEventName, callback); // TODO
   }
 
-  public onUserTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): void {
+  public async onUserTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Promise<any> {
     this._ensureIsAuthorized(identity);
 
     const decodedIdentity: TokenBody = <TokenBody> jsonwebtoken.decode(identity.token);
@@ -71,40 +72,42 @@ export class ExternalAccessor implements IConsumerApiAccessor {
     const socketEventName: string = socketSettings.paths.userTaskForIdentityFinished
       .replace(socketSettings.pathParams.userId, userId);
 
-    this._socket.on(socketEventName, callback);
+    this._socket.on(socketEventName, callback); // TODO
   }
 
-  public onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): void {
+  public async onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): Promise<any> {
     this._ensureIsAuthorized(identity);
-    this._socket.on(socketSettings.paths.processTerminated, callback);
+    this._socket.on(socketSettings.paths.processTerminated, callback); // TODO
   }
 
-  public onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): void {
+  public async onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): Promise<any> {
     this._ensureIsAuthorized(identity);
-    this._socket.on(socketSettings.paths.processStarted, callback);
+    this._socket.on(socketSettings.paths.processStarted, callback); // TODO
   }
 
-  public onProcessWithProcessModelIdStarted(identity: IIdentity,
-                                            callback: Messages.CallbackTypes.OnProcessStartedCallback,
-                                            processModelId: string): void {
+  public async onProcessWithProcessModelIdStarted(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnProcessStartedCallback,
+    processModelId: string,
+  ): Promise<any> {
     this._ensureIsAuthorized(identity);
     const eventName: string = socketSettings.paths.processInstanceStarted
       .replace(socketSettings.pathParams.processModelId, processModelId);
 
-    this._socket.on(eventName, callback);
+    this._socket.on(eventName, callback); // TODO
   }
 
-  public onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): void {
+  public async onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Promise<any> {
     this._ensureIsAuthorized(identity);
-    this._socket.on(socketSettings.paths.manualTaskWaiting, callback);
+    this._socket.on(socketSettings.paths.manualTaskWaiting, callback); // TODO
   }
 
-  public onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): void {
+  public async onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Promise<any> {
     this._ensureIsAuthorized(identity);
-    this._socket.on(socketSettings.paths.manualTaskFinished, callback);
+    this._socket.on(socketSettings.paths.manualTaskFinished, callback); // TODO
   }
 
-  public onManualTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): void {
+  public async onManualTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Promise<any> {
     this._ensureIsAuthorized(identity);
 
     const decodedIdentity: TokenBody = <TokenBody> jsonwebtoken.decode(identity.token);
@@ -113,10 +116,10 @@ export class ExternalAccessor implements IConsumerApiAccessor {
     const socketEventName: string = socketSettings.paths.manualTaskForIdentityWaiting
       .replace(socketSettings.pathParams.userId, userId);
 
-    this._socket.on(socketEventName, callback);
+    this._socket.on(socketEventName, callback); // TODO
   }
 
-  public onManualTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): void {
+  public async onManualTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Promise<any> {
     this._ensureIsAuthorized(identity);
 
     const decodedIdentity: TokenBody = <TokenBody> jsonwebtoken.decode(identity.token);
@@ -125,12 +128,12 @@ export class ExternalAccessor implements IConsumerApiAccessor {
     const socketEventName: string = socketSettings.paths.manualTaskForIdentityFinished
       .replace(socketSettings.pathParams.userId, userId);
 
-    this._socket.on(socketEventName, callback);
+    this._socket.on(socketEventName, callback); // TODO
   }
 
-  public onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): void {
+  public async onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): Promise<any> {
     this._ensureIsAuthorized(identity);
-    this._socket.on(socketSettings.paths.processEnded, callback);
+    this._socket.on(socketSettings.paths.processEnded, callback); // TODO
   }
 
   // Process models and instances

--- a/typescript/src/accessors/external_accessor.ts
+++ b/typescript/src/accessors/external_accessor.ts
@@ -5,7 +5,7 @@ import * as uuid from 'uuid';
 import {UnauthorizedError} from '@essential-projects/errors_ts';
 import {Subscription} from '@essential-projects/event_aggregator_contracts';
 import {IHttpClient, IRequestOptions, IResponse} from '@essential-projects/http_contracts';
-import {IIdentity, TokenBody} from '@essential-projects/iam_contracts';
+import {IIdentity} from '@essential-projects/iam_contracts';
 
 import {
   DataModels,

--- a/typescript/src/accessors/external_accessor.ts
+++ b/typescript/src/accessors/external_accessor.ts
@@ -213,14 +213,15 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     return httpResponse.result;
   }
 
-  public async startProcessInstance(identity: IIdentity,
-                                    processModelId: string,
-                                    startEventId: string,
-                                    payload: DataModels.ProcessModels.ProcessStartRequestPayload,
-                                    startCallbackType: DataModels.ProcessModels.StartCallbackType,
-                                    endEventId?: string,
-                                    processEndedCallback?: Messages.CallbackTypes.OnProcessEndedCallback,
-                                  ): Promise<DataModels.ProcessModels.ProcessStartResponsePayload> {
+  public async startProcessInstance(
+    identity: IIdentity,
+    processModelId: string,
+    startEventId: string,
+    payload: DataModels.ProcessModels.ProcessStartRequestPayload,
+    startCallbackType: DataModels.ProcessModels.StartCallbackType,
+    endEventId?: string,
+    processEndedCallback?: Messages.CallbackTypes.OnProcessEndedCallback,
+  ): Promise<DataModels.ProcessModels.ProcessStartResponsePayload> {
 
     const url: string = this._buildStartProcessInstanceUrl(processModelId, startEventId, startCallbackType, endEventId);
 
@@ -240,10 +241,12 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     return httpResponse.result;
   }
 
-  private _buildStartProcessInstanceUrl(processModelId: string,
-                                        startEventId: string,
-                                        startCallbackType: DataModels.ProcessModels.StartCallbackType,
-                                        endEventId: string): string {
+  private _buildStartProcessInstanceUrl(
+    processModelId: string,
+    startEventId: string,
+    startCallbackType: DataModels.ProcessModels.StartCallbackType,
+    endEventId: string,
+  ): string {
     let url: string = restSettings.paths.startProcessInstance
       .replace(restSettings.params.processModelId, processModelId)
       .replace(restSettings.params.startEventId, startEventId);
@@ -260,9 +263,11 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     return url;
   }
 
-  public async getProcessResultForCorrelation(identity: IIdentity,
-                                              correlationId: string,
-                                              processModelId: string): Promise<Array<DataModels.CorrelationResult>> {
+  public async getProcessResultForCorrelation(
+    identity: IIdentity,
+    correlationId: string,
+    processModelId: string,
+  ): Promise<Array<DataModels.CorrelationResult>> {
     let url: string = restSettings.paths.getProcessResultForCorrelation
       .replace(restSettings.params.correlationId, correlationId)
       .replace(restSettings.params.processModelId, processModelId);
@@ -377,9 +382,11 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     return httpResponse.result;
   }
 
-  public async getUserTasksForProcessModelInCorrelation(identity: IIdentity,
-                                                        processModelId: string,
-                                                        correlationId: string): Promise<DataModels.UserTasks.UserTaskList> {
+  public async getUserTasksForProcessModelInCorrelation(
+    identity: IIdentity,
+    processModelId: string,
+    correlationId: string,
+  ): Promise<DataModels.UserTasks.UserTaskList> {
     const requestAuthHeaders: IRequestOptions = this._createRequestAuthHeaders(identity);
 
     let url: string = restSettings.paths.processModelCorrelationUserTasks
@@ -406,11 +413,13 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     return httpResponse.result;
   }
 
-  public async finishUserTask(identity: IIdentity,
-                              processInstanceId: string,
-                              correlationId: string,
-                              userTaskInstanceId: string,
-                              userTaskResult: DataModels.UserTasks.UserTaskResult): Promise<void> {
+  public async finishUserTask(
+    identity: IIdentity,
+    processInstanceId: string,
+    correlationId: string,
+    userTaskInstanceId: string,
+    userTaskResult: DataModels.UserTasks.UserTaskResult,
+  ): Promise<void> {
     const requestAuthHeaders: IRequestOptions = this._createRequestAuthHeaders(identity);
 
     let url: string = restSettings.paths.finishUserTask
@@ -452,9 +461,11 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     return httpResponse.result;
   }
 
-  public async getManualTasksForProcessModelInCorrelation(identity: IIdentity,
-                                                          processModelId: string,
-                                                          correlationId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
+  public async getManualTasksForProcessModelInCorrelation(
+    identity: IIdentity,
+    processModelId: string,
+    correlationId: string,
+  ): Promise<DataModels.ManualTasks.ManualTaskList> {
     const requestAuthHeaders: IRequestOptions = this._createRequestAuthHeaders(identity);
 
     const urlRestPart: string = restSettings.paths.processModelCorrelationManualTasks
@@ -481,10 +492,12 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     return httpResponse.result;
   }
 
-  public async finishManualTask(identity: IIdentity,
-                                processInstanceId: string,
-                                correlationId: string,
-                                manualTaskInstanceId: string): Promise<void> {
+  public async finishManualTask(
+    identity: IIdentity,
+    processInstanceId: string,
+    correlationId: string,
+    manualTaskInstanceId: string,
+  ): Promise<void> {
     const requestAuthHeaders: IRequestOptions = this._createRequestAuthHeaders(identity);
 
     const urlRestPart: string = restSettings.paths.finishManualTask

--- a/typescript/src/accessors/internal_accessor.ts
+++ b/typescript/src/accessors/internal_accessor.ts
@@ -19,89 +19,125 @@ export class InternalAccessor implements IConsumerApiAccessor {
   }
 
   // Notifications
-  public async onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<Subscription> {
+  public async onUserTaskWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
 
-    return this._consumerApiService.onUserTaskWaiting(identity, callback);
+    return this._consumerApiService.onUserTaskWaiting(identity, callback, subscribeOnce);
   }
 
-  public async onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Promise<Subscription> {
+  public async onUserTaskFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
 
-    return this._consumerApiService.onUserTaskFinished(identity, callback);
+    return this._consumerApiService.onUserTaskFinished(identity, callback, subscribeOnce);
   }
 
-  public async onUserTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<Subscription> {
+  public async onUserTaskForIdentityWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
 
-    return this._consumerApiService.onUserTaskForIdentityWaiting(identity, callback);
+    return this._consumerApiService.onUserTaskForIdentityWaiting(identity, callback, subscribeOnce);
   }
 
   public async onUserTaskForIdentityFinished(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
+    subscribeOnce: boolean = false,
   ): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
 
-    return this._consumerApiService.onUserTaskForIdentityFinished(identity, callback);
+    return this._consumerApiService.onUserTaskForIdentityFinished(identity, callback, subscribeOnce);
   }
 
-  public async onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Promise<Subscription> {
+  public async onManualTaskWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
 
-    return this._consumerApiService.onManualTaskWaiting(identity, callback);
+    return this._consumerApiService.onManualTaskWaiting(identity, callback, subscribeOnce);
   }
 
-  public async onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Promise<Subscription> {
+  public async onManualTaskFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
 
-    return this._consumerApiService.onManualTaskFinished(identity, callback);
+    return this._consumerApiService.onManualTaskFinished(identity, callback, subscribeOnce);
   }
 
   public async onManualTaskForIdentityWaiting(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
+    subscribeOnce: boolean = false,
   ): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
 
-    return this._consumerApiService.onManualTaskForIdentityWaiting(identity, callback);
+    return this._consumerApiService.onManualTaskForIdentityWaiting(identity, callback, subscribeOnce);
   }
 
   public async onManualTaskForIdentityFinished(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
+    subscribeOnce: boolean = false,
   ): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
 
-    return this._consumerApiService.onManualTaskForIdentityFinished(identity, callback);
+    return this._consumerApiService.onManualTaskForIdentityFinished(identity, callback, subscribeOnce);
   }
 
-  public async onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): Promise<Subscription> {
+  public async onProcessStarted(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnProcessStartedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
 
-    return this._consumerApiService.onProcessStarted(identity, callback);
+    return this._consumerApiService.onProcessStarted(identity, callback, subscribeOnce);
   }
 
   public async onProcessWithProcessModelIdStarted(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnProcessStartedCallback,
     processModelId: string,
+    subscribeOnce: boolean = false,
   ): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
 
-    return this._consumerApiService.onProcessWithProcessModelIdStarted(identity, callback, processModelId);
+    return this._consumerApiService.onProcessWithProcessModelIdStarted(identity, callback, processModelId, subscribeOnce);
   }
 
-  public async onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): Promise<Subscription> {
+  public async onProcessTerminated(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnProcessTerminatedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
 
-    return this._consumerApiService.onProcessTerminated(identity, callback);
+    return this._consumerApiService.onProcessTerminated(identity, callback, subscribeOnce);
   }
 
-  public async onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): Promise<Subscription> {
+  public async onProcessEnded(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnProcessEndedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
 
-    return this._consumerApiService.onProcessEnded(identity, callback);
+    return this._consumerApiService.onProcessEnded(identity, callback, subscribeOnce);
   }
 
   public async removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void> {

--- a/typescript/src/accessors/internal_accessor.ts
+++ b/typescript/src/accessors/internal_accessor.ts
@@ -104,6 +104,12 @@ export class InternalAccessor implements IConsumerApiAccessor {
     return this._consumerApiService.onProcessEnded(identity, callback);
   }
 
+  public async removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void> {
+    this._ensureIsAuthorized(identity);
+
+    return this._consumerApiService.removeSubscription(identity, subscription);
+  }
+
   // Process models and instances
   public async getProcessModels(identity: IIdentity): Promise<DataModels.ProcessModels.ProcessModelList> {
 

--- a/typescript/src/accessors/internal_accessor.ts
+++ b/typescript/src/accessors/internal_accessor.ts
@@ -1,3 +1,4 @@
+import {Subscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
 import {
@@ -18,66 +19,89 @@ export class InternalAccessor implements IConsumerApiAccessor {
   }
 
   // Notifications
-  public onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): void {
+  public async onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
-    this._consumerApiService.onUserTaskWaiting(identity, callback);
+
+    return this._consumerApiService.onUserTaskWaiting(identity, callback);
   }
 
-  public onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): void {
+  public async onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
-    this._consumerApiService.onUserTaskFinished(identity, callback);
+
+    return this._consumerApiService.onUserTaskFinished(identity, callback);
   }
 
-  public onUserTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): void {
+  public async onUserTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
-    this._consumerApiService.onUserTaskForIdentityWaiting(identity, callback);
+
+    return this._consumerApiService.onUserTaskForIdentityWaiting(identity, callback);
   }
 
-  public onUserTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): void {
+  public async onUserTaskForIdentityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
+  ): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
-    this._consumerApiService.onUserTaskForIdentityFinished(identity, callback);
+
+    return this._consumerApiService.onUserTaskForIdentityFinished(identity, callback);
   }
 
-  public onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): void {
+  public async onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
-    this._consumerApiService.onManualTaskWaiting(identity, callback);
+
+    return this._consumerApiService.onManualTaskWaiting(identity, callback);
   }
 
-  public onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): void {
+  public async onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
-    this._consumerApiService.onManualTaskFinished(identity, callback);
+
+    return this._consumerApiService.onManualTaskFinished(identity, callback);
   }
 
-  public onManualTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): void {
+  public async onManualTaskForIdentityWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
+  ): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
-    this._consumerApiService.onManualTaskForIdentityWaiting(identity, callback);
+
+    return this._consumerApiService.onManualTaskForIdentityWaiting(identity, callback);
   }
 
-  public onManualTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): void {
+  public async onManualTaskForIdentityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
+  ): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
-    this._consumerApiService.onManualTaskForIdentityFinished(identity, callback);
+
+    return this._consumerApiService.onManualTaskForIdentityFinished(identity, callback);
   }
 
-  public onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): void {
+  public async onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
-    this._consumerApiService.onProcessStarted(identity, callback);
+
+    return this._consumerApiService.onProcessStarted(identity, callback);
   }
 
-  public onProcessWithProcessModelIdStarted(identity: IIdentity,
-                                            callback: Messages.CallbackTypes.OnProcessStartedCallback,
-                                            processModelId: string): void {
+  public async onProcessWithProcessModelIdStarted(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnProcessStartedCallback,
+    processModelId: string,
+  ): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
-    this._consumerApiService.onProcessWithProcessModelIdStarted(identity, callback, processModelId);
+
+    return this._consumerApiService.onProcessWithProcessModelIdStarted(identity, callback, processModelId);
   }
 
-  public onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): void {
+  public async onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
-    this._consumerApiService.onProcessTerminated(identity, callback);
+
+    return this._consumerApiService.onProcessTerminated(identity, callback);
   }
 
-  public onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): void {
+  public async onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
-    this._consumerApiService.onProcessEnded(identity, callback);
+
+    return this._consumerApiService.onProcessEnded(identity, callback);
   }
 
   // Process models and instances

--- a/typescript/src/accessors/internal_accessor.ts
+++ b/typescript/src/accessors/internal_accessor.ts
@@ -120,29 +120,30 @@ export class InternalAccessor implements IConsumerApiAccessor {
 
   // Process models and instances
   public async getProcessModels(identity: IIdentity): Promise<DataModels.ProcessModels.ProcessModelList> {
-
     return this._consumerApiService.getProcessModels(identity);
   }
 
   public async getProcessModelById(identity: IIdentity, processModelId: string): Promise<DataModels.ProcessModels.ProcessModel> {
-
     return this._consumerApiService.getProcessModelById(identity, processModelId);
   }
 
-  public async startProcessInstance(identity: IIdentity,
-                                    processModelId: string,
-                                    startEventId: string,
-                                    payload: DataModels.ProcessModels.ProcessStartRequestPayload,
-                                    startCallbackType?: DataModels.ProcessModels.StartCallbackType,
-                                    endEventId?: string,
-                                  ): Promise<DataModels.ProcessModels.ProcessStartResponsePayload> {
+  public async startProcessInstance(
+    identity: IIdentity,
+    processModelId: string,
+    startEventId: string,
+    payload: DataModels.ProcessModels.ProcessStartRequestPayload,
+    startCallbackType?: DataModels.ProcessModels.StartCallbackType,
+    endEventId?: string,
+  ): Promise<DataModels.ProcessModels.ProcessStartResponsePayload> {
 
     return this._consumerApiService.startProcessInstance(identity, processModelId, startEventId, payload, startCallbackType, endEventId);
   }
 
-  public async getProcessResultForCorrelation(identity: IIdentity,
-                                              correlationId: string,
-                                              processModelId: string): Promise<Array<DataModels.CorrelationResult>> {
+  public async getProcessResultForCorrelation(
+    identity: IIdentity,
+    correlationId: string,
+    processModelId: string,
+  ): Promise<Array<DataModels.CorrelationResult>> {
 
     return this._consumerApiService.getProcessResultForCorrelation(identity, correlationId, processModelId);
   }
@@ -165,6 +166,7 @@ export class InternalAccessor implements IConsumerApiAccessor {
     processModelId: string,
     correlationId: string,
   ): Promise<DataModels.Events.EventList> {
+
     return this._consumerApiService.getEventsForProcessModelInCorrelation(identity, processModelId, correlationId);
   }
 
@@ -185,9 +187,12 @@ export class InternalAccessor implements IConsumerApiAccessor {
     return this._consumerApiService.getUserTasksForCorrelation(identity, correlationId);
   }
 
-  public async getUserTasksForProcessModelInCorrelation(identity: IIdentity,
-                                                        processModelId: string,
-                                                        correlationId: string): Promise<DataModels.UserTasks.UserTaskList> {
+  public async getUserTasksForProcessModelInCorrelation(
+    identity: IIdentity,
+    processModelId: string,
+    correlationId: string,
+  ): Promise<DataModels.UserTasks.UserTaskList> {
+
     return this._consumerApiService.getUserTasksForProcessModelInCorrelation(identity, processModelId, correlationId);
   }
 
@@ -195,11 +200,14 @@ export class InternalAccessor implements IConsumerApiAccessor {
     return this._consumerApiService.getWaitingUserTasksByIdentity(identity);
   }
 
-  public async finishUserTask(identity: IIdentity,
-                              processInstanceId: string,
-                              correlationId: string,
-                              userTaskInstanceId: string,
-                              userTaskResult: DataModels.UserTasks.UserTaskResult): Promise<void> {
+  public async finishUserTask(
+    identity: IIdentity,
+    processInstanceId: string,
+    correlationId: string,
+    userTaskInstanceId: string,
+    userTaskResult: DataModels.UserTasks.UserTaskResult,
+  ): Promise<void> {
+
     return this._consumerApiService.finishUserTask(identity, processInstanceId, correlationId, userTaskInstanceId, userTaskResult);
   }
 
@@ -212,9 +220,12 @@ export class InternalAccessor implements IConsumerApiAccessor {
     return this._consumerApiService.getManualTasksForCorrelation(identity, correlationId);
   }
 
-  public async getManualTasksForProcessModelInCorrelation(identity: IIdentity,
-                                                          processModelId: string,
-                                                          correlationId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
+  public async getManualTasksForProcessModelInCorrelation(
+    identity: IIdentity,
+    processModelId: string,
+    correlationId: string,
+  ): Promise<DataModels.ManualTasks.ManualTaskList> {
+
     return this._consumerApiService.getManualTasksForProcessModelInCorrelation(identity, processModelId, correlationId);
   }
 
@@ -222,10 +233,13 @@ export class InternalAccessor implements IConsumerApiAccessor {
     return this._consumerApiService.getWaitingManualTasksByIdentity(identity);
   }
 
-  public async finishManualTask(identity: IIdentity,
-                                processInstanceId: string,
-                                correlationId: string,
-                                manualTaskInstanceId: string): Promise<void> {
+  public async finishManualTask(
+    identity: IIdentity,
+    processInstanceId: string,
+    correlationId: string,
+    manualTaskInstanceId: string,
+  ): Promise<void> {
+
     return this._consumerApiService.finishManualTask(identity, processInstanceId, correlationId, manualTaskInstanceId);
   }
 }

--- a/typescript/src/accessors/internal_accessor.ts
+++ b/typescript/src/accessors/internal_accessor.ts
@@ -8,8 +8,6 @@ import {
   Messages,
 } from '@process-engine/consumer_api_contracts';
 
-import {UnauthorizedError} from '@essential-projects/errors_ts';
-
 export class InternalAccessor implements IConsumerApiAccessor {
 
   private _consumerApiService: IConsumerApi = undefined;
@@ -24,8 +22,6 @@ export class InternalAccessor implements IConsumerApiAccessor {
     callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.onUserTaskWaiting(identity, callback, subscribeOnce);
   }
 
@@ -34,8 +30,6 @@ export class InternalAccessor implements IConsumerApiAccessor {
     callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.onUserTaskFinished(identity, callback, subscribeOnce);
   }
 
@@ -44,8 +38,6 @@ export class InternalAccessor implements IConsumerApiAccessor {
     callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.onUserTaskForIdentityWaiting(identity, callback, subscribeOnce);
   }
 
@@ -54,8 +46,6 @@ export class InternalAccessor implements IConsumerApiAccessor {
     callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.onUserTaskForIdentityFinished(identity, callback, subscribeOnce);
   }
 
@@ -64,8 +54,6 @@ export class InternalAccessor implements IConsumerApiAccessor {
     callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.onManualTaskWaiting(identity, callback, subscribeOnce);
   }
 
@@ -74,8 +62,6 @@ export class InternalAccessor implements IConsumerApiAccessor {
     callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.onManualTaskFinished(identity, callback, subscribeOnce);
   }
 
@@ -84,8 +70,6 @@ export class InternalAccessor implements IConsumerApiAccessor {
     callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.onManualTaskForIdentityWaiting(identity, callback, subscribeOnce);
   }
 
@@ -94,8 +78,6 @@ export class InternalAccessor implements IConsumerApiAccessor {
     callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.onManualTaskForIdentityFinished(identity, callback, subscribeOnce);
   }
 
@@ -104,8 +86,6 @@ export class InternalAccessor implements IConsumerApiAccessor {
     callback: Messages.CallbackTypes.OnProcessStartedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.onProcessStarted(identity, callback, subscribeOnce);
   }
 
@@ -115,8 +95,6 @@ export class InternalAccessor implements IConsumerApiAccessor {
     processModelId: string,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.onProcessWithProcessModelIdStarted(identity, callback, processModelId, subscribeOnce);
   }
 
@@ -125,8 +103,6 @@ export class InternalAccessor implements IConsumerApiAccessor {
     callback: Messages.CallbackTypes.OnProcessTerminatedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.onProcessTerminated(identity, callback, subscribeOnce);
   }
 
@@ -135,28 +111,20 @@ export class InternalAccessor implements IConsumerApiAccessor {
     callback: Messages.CallbackTypes.OnProcessEndedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.onProcessEnded(identity, callback, subscribeOnce);
   }
 
   public async removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void> {
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.removeSubscription(identity, subscription);
   }
 
   // Process models and instances
   public async getProcessModels(identity: IIdentity): Promise<DataModels.ProcessModels.ProcessModelList> {
 
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.getProcessModels(identity);
   }
 
   public async getProcessModelById(identity: IIdentity, processModelId: string): Promise<DataModels.ProcessModels.ProcessModel> {
-
-    this._ensureIsAuthorized(identity);
 
     return this._consumerApiService.getProcessModelById(identity, processModelId);
   }
@@ -169,8 +137,6 @@ export class InternalAccessor implements IConsumerApiAccessor {
                                     endEventId?: string,
                                   ): Promise<DataModels.ProcessModels.ProcessStartResponsePayload> {
 
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.startProcessInstance(identity, processModelId, startEventId, payload, startCallbackType, endEventId);
   }
 
@@ -178,27 +144,19 @@ export class InternalAccessor implements IConsumerApiAccessor {
                                               correlationId: string,
                                               processModelId: string): Promise<Array<DataModels.CorrelationResult>> {
 
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.getProcessResultForCorrelation(identity, correlationId, processModelId);
   }
 
   public async getProcessInstancesByIdentity(identity: IIdentity): Promise<Array<DataModels.ProcessInstance>> {
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.getProcessInstancesByIdentity(identity);
   }
 
   // Events
   public async getEventsForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.Events.EventList> {
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.getEventsForProcessModel(identity, processModelId);
   }
 
   public async getEventsForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.Events.EventList> {
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.getEventsForCorrelation(identity, correlationId);
   }
 
@@ -207,47 +165,33 @@ export class InternalAccessor implements IConsumerApiAccessor {
     processModelId: string,
     correlationId: string,
   ): Promise<DataModels.Events.EventList> {
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.getEventsForProcessModelInCorrelation(identity, processModelId, correlationId);
   }
 
   public async triggerMessageEvent(identity: IIdentity, messageName: string, payload?: DataModels.Events.EventTriggerPayload): Promise<void> {
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.triggerMessageEvent(identity, messageName, payload);
   }
 
   public async triggerSignalEvent(identity: IIdentity, signalName: string, payload?: DataModels.Events.EventTriggerPayload): Promise<void> {
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.triggerSignalEvent(identity, signalName, payload);
   }
 
   // UserTasks
   public async getUserTasksForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.UserTasks.UserTaskList> {
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.getUserTasksForProcessModel(identity, processModelId);
   }
 
   public async getUserTasksForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.UserTasks.UserTaskList> {
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.getUserTasksForCorrelation(identity, correlationId);
   }
 
   public async getUserTasksForProcessModelInCorrelation(identity: IIdentity,
                                                         processModelId: string,
                                                         correlationId: string): Promise<DataModels.UserTasks.UserTaskList> {
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.getUserTasksForProcessModelInCorrelation(identity, processModelId, correlationId);
   }
 
   public async getWaitingUserTasksByIdentity(identity: IIdentity): Promise<DataModels.UserTasks.UserTaskList> {
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.getWaitingUserTasksByIdentity(identity);
   }
 
@@ -256,35 +200,25 @@ export class InternalAccessor implements IConsumerApiAccessor {
                               correlationId: string,
                               userTaskInstanceId: string,
                               userTaskResult: DataModels.UserTasks.UserTaskResult): Promise<void> {
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.finishUserTask(identity, processInstanceId, correlationId, userTaskInstanceId, userTaskResult);
   }
 
   // ManualTasks
   public async getManualTasksForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.getManualTasksForProcessModel(identity, processModelId);
   }
 
   public async getManualTasksForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.getManualTasksForCorrelation(identity, correlationId);
   }
 
   public async getManualTasksForProcessModelInCorrelation(identity: IIdentity,
                                                           processModelId: string,
                                                           correlationId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.getManualTasksForProcessModelInCorrelation(identity, processModelId, correlationId);
   }
 
   public async getWaitingManualTasksByIdentity(identity: IIdentity): Promise<DataModels.ManualTasks.ManualTaskList> {
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.getWaitingManualTasksByIdentity(identity);
   }
 
@@ -292,18 +226,6 @@ export class InternalAccessor implements IConsumerApiAccessor {
                                 processInstanceId: string,
                                 correlationId: string,
                                 manualTaskInstanceId: string): Promise<void> {
-    this._ensureIsAuthorized(identity);
-
     return this._consumerApiService.finishManualTask(identity, processInstanceId, correlationId, manualTaskInstanceId);
-  }
-
-  private _ensureIsAuthorized(identity: IIdentity): void {
-
-    // Note: When using an external accessor, this check is performed by the ConsumerApiHttp module.
-    // Since that component is bypassed by the internal accessor, we need to perform this check here.
-    const noAuthTokenProvided: boolean = !identity || typeof identity.token !== 'string';
-    if (noAuthTokenProvided) {
-      throw new UnauthorizedError('No auth token provided!');
-    }
   }
 }

--- a/typescript/src/consumer_api_client_service.ts
+++ b/typescript/src/consumer_api_client_service.ts
@@ -1,4 +1,5 @@
 import * as EssentialProjectErrors from '@essential-projects/errors_ts';
+import {Subscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
 import {
@@ -17,54 +18,65 @@ export class ConsumerApiClientService implements IConsumerApi {
   }
 
   // Notifications
-  public onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): void {
-    this.consumerApiAccessor.onUserTaskWaiting(identity, callback);
+  public async onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<Subscription> {
+    return this.consumerApiAccessor.onUserTaskWaiting(identity, callback);
   }
 
-  public onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): void {
-    this.consumerApiAccessor.onUserTaskFinished(identity, callback);
+  public async onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Promise<Subscription> {
+    return this.consumerApiAccessor.onUserTaskFinished(identity, callback);
   }
 
-  public onUserTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): void {
-    this.consumerApiAccessor.onUserTaskForIdentityWaiting(identity, callback);
+  public async onUserTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<Subscription> {
+    return this.consumerApiAccessor.onUserTaskForIdentityWaiting(identity, callback);
   }
 
-  public onUserTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): void {
-    this.consumerApiAccessor.onUserTaskForIdentityFinished(identity, callback);
+  public async onUserTaskForIdentityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
+  ): Promise<Subscription> {
+    return this.consumerApiAccessor.onUserTaskForIdentityFinished(identity, callback);
   }
 
-  public onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): void {
-    this.consumerApiAccessor.onProcessTerminated(identity, callback);
+  public async onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): Promise<Subscription> {
+    return this.consumerApiAccessor.onProcessTerminated(identity, callback);
   }
 
-  public onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): void {
-    this.consumerApiAccessor.onProcessStarted(identity, callback);
+  public async onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): Promise<Subscription> {
+    return this.consumerApiAccessor.onProcessStarted(identity, callback);
   }
 
-  public onProcessWithProcessModelIdStarted(identity: IIdentity,
-                                            callback: Messages.CallbackTypes.OnProcessStartedCallback,
-                                            processModelId: string): void {
-    this.consumerApiAccessor.onProcessWithProcessModelIdStarted(identity, callback, processModelId);
+  public async onProcessWithProcessModelIdStarted(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnProcessStartedCallback,
+    processModelId: string,
+  ): Promise<Subscription> {
+    return this.consumerApiAccessor.onProcessWithProcessModelIdStarted(identity, callback, processModelId);
   }
 
-  public onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): void {
-    this.consumerApiAccessor.onManualTaskWaiting(identity, callback);
+  public async onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Promise<Subscription> {
+    return this.consumerApiAccessor.onManualTaskWaiting(identity, callback);
   }
 
-  public onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): void {
-    this.consumerApiAccessor.onManualTaskFinished(identity, callback);
+  public async onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Promise<Subscription> {
+    return this.consumerApiAccessor.onManualTaskFinished(identity, callback);
   }
 
-  public onManualTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): void {
-    this.consumerApiAccessor.onManualTaskForIdentityWaiting(identity, callback);
+  public async onManualTaskForIdentityWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
+  ): Promise<Subscription> {
+    return this.consumerApiAccessor.onManualTaskForIdentityWaiting(identity, callback);
   }
 
-  public onManualTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): void {
-    this.consumerApiAccessor.onManualTaskForIdentityFinished(identity, callback);
+  public async onManualTaskForIdentityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
+  ): Promise<Subscription> {
+    return this.consumerApiAccessor.onManualTaskForIdentityFinished(identity, callback);
   }
 
-  public onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): void {
-    this.consumerApiAccessor.onProcessEnded(identity, callback);
+  public async onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): Promise<Subscription> {
+    return this.consumerApiAccessor.onProcessEnded(identity, callback);
   }
 
   // Process models and instances

--- a/typescript/src/consumer_api_client_service.ts
+++ b/typescript/src/consumer_api_client_service.ts
@@ -23,6 +23,8 @@ export class ConsumerApiClientService implements IConsumerApi {
     callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
+    this._ensureIsAuthorized(identity);
+
     return this.consumerApiAccessor.onUserTaskWaiting(identity, callback, subscribeOnce);
   }
 
@@ -31,6 +33,8 @@ export class ConsumerApiClientService implements IConsumerApi {
     callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
+    this._ensureIsAuthorized(identity);
+
     return this.consumerApiAccessor.onUserTaskFinished(identity, callback, subscribeOnce);
   }
 
@@ -39,6 +43,8 @@ export class ConsumerApiClientService implements IConsumerApi {
     callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
+    this._ensureIsAuthorized(identity);
+
     return this.consumerApiAccessor.onUserTaskForIdentityWaiting(identity, callback, subscribeOnce);
   }
 
@@ -47,6 +53,8 @@ export class ConsumerApiClientService implements IConsumerApi {
     callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
+    this._ensureIsAuthorized(identity);
+
     return this.consumerApiAccessor.onUserTaskForIdentityFinished(identity, callback, subscribeOnce);
   }
 
@@ -55,6 +63,8 @@ export class ConsumerApiClientService implements IConsumerApi {
     callback: Messages.CallbackTypes.OnProcessTerminatedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
+    this._ensureIsAuthorized(identity);
+
     return this.consumerApiAccessor.onProcessTerminated(identity, callback, subscribeOnce);
   }
 
@@ -63,6 +73,8 @@ export class ConsumerApiClientService implements IConsumerApi {
     callback: Messages.CallbackTypes.OnProcessStartedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
+    this._ensureIsAuthorized(identity);
+
     return this.consumerApiAccessor.onProcessStarted(identity, callback, subscribeOnce);
   }
 
@@ -72,6 +84,8 @@ export class ConsumerApiClientService implements IConsumerApi {
     processModelId: string,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
+    this._ensureIsAuthorized(identity);
+
     return this.consumerApiAccessor.onProcessWithProcessModelIdStarted(identity, callback, processModelId, subscribeOnce);
   }
 
@@ -80,6 +94,8 @@ export class ConsumerApiClientService implements IConsumerApi {
     callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
+    this._ensureIsAuthorized(identity);
+
     return this.consumerApiAccessor.onManualTaskWaiting(identity, callback, subscribeOnce);
   }
 
@@ -88,6 +104,8 @@ export class ConsumerApiClientService implements IConsumerApi {
     callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
+    this._ensureIsAuthorized(identity);
+
     return this.consumerApiAccessor.onManualTaskFinished(identity, callback, subscribeOnce);
   }
 
@@ -96,6 +114,8 @@ export class ConsumerApiClientService implements IConsumerApi {
     callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
+    this._ensureIsAuthorized(identity);
+
     return this.consumerApiAccessor.onManualTaskForIdentityWaiting(identity, callback, subscribeOnce);
   }
 
@@ -104,6 +124,8 @@ export class ConsumerApiClientService implements IConsumerApi {
     callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
+    this._ensureIsAuthorized(identity);
+
     return this.consumerApiAccessor.onManualTaskForIdentityFinished(identity, callback, subscribeOnce);
   }
 
@@ -112,19 +134,27 @@ export class ConsumerApiClientService implements IConsumerApi {
     callback: Messages.CallbackTypes.OnProcessEndedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
+    this._ensureIsAuthorized(identity);
+
     return this.consumerApiAccessor.onProcessEnded(identity, callback, subscribeOnce);
   }
 
   public async removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void> {
+    this._ensureIsAuthorized(identity);
+
     return this.consumerApiAccessor.removeSubscription(identity, subscription);
   }
 
   // Process models and instances
   public async getProcessModels(identity: IIdentity): Promise<DataModels.ProcessModels.ProcessModelList> {
+    this._ensureIsAuthorized(identity);
+
     return this.consumerApiAccessor.getProcessModels(identity);
   }
 
   public async getProcessModelById(identity: IIdentity, processModelId: string): Promise<DataModels.ProcessModels.ProcessModel> {
+    this._ensureIsAuthorized(identity);
+
     return this.consumerApiAccessor.getProcessModelById(identity, processModelId);
   }
 
@@ -135,6 +165,7 @@ export class ConsumerApiClientService implements IConsumerApi {
                                     startCallbackType?: DataModels.ProcessModels.StartCallbackType,
                                     endEventId?: string,
                                   ): Promise<DataModels.ProcessModels.ProcessStartResponsePayload> {
+    this._ensureIsAuthorized(identity);
 
     const useDefaultStartCallbackType: boolean = !startCallbackType;
     if (useDefaultStartCallbackType) {
@@ -159,20 +190,27 @@ export class ConsumerApiClientService implements IConsumerApi {
     correlationId: string,
     processModelId: string,
   ): Promise<Array<DataModels.CorrelationResult>> {
+    this._ensureIsAuthorized(identity);
 
     return this.consumerApiAccessor.getProcessResultForCorrelation(identity, correlationId, processModelId);
   }
 
   public async getProcessInstancesByIdentity(identity: IIdentity): Promise<Array<DataModels.ProcessInstance>> {
+    this._ensureIsAuthorized(identity);
+
     return this.consumerApiAccessor.getProcessInstancesByIdentity(identity);
   }
 
   // Events
   public async getEventsForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.Events.EventList> {
+    this._ensureIsAuthorized(identity);
+
     return this.consumerApiAccessor.getEventsForProcessModel(identity, processModelId);
   }
 
   public async getEventsForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.Events.EventList> {
+    this._ensureIsAuthorized(identity);
+
     return this.consumerApiAccessor.getEventsForCorrelation(identity, correlationId);
   }
 
@@ -181,29 +219,42 @@ export class ConsumerApiClientService implements IConsumerApi {
     processModelId: string,
     correlationId: string,
   ): Promise<DataModels.Events.EventList> {
+    this._ensureIsAuthorized(identity);
+
     return this.consumerApiAccessor.getEventsForProcessModelInCorrelation(identity, processModelId, correlationId);
   }
 
   public async triggerMessageEvent(identity: IIdentity, messageName: string, payload?: DataModels.Events.EventTriggerPayload): Promise<void> {
+    this._ensureIsAuthorized(identity);
+
     return this.consumerApiAccessor.triggerMessageEvent(identity, messageName, payload);
   }
 
   public async triggerSignalEvent(identity: IIdentity, signalName: string, payload?: DataModels.Events.EventTriggerPayload): Promise<void> {
+    this._ensureIsAuthorized(identity);
+
     return this.consumerApiAccessor.triggerSignalEvent(identity, signalName, payload);
   }
 
   // UserTasks
   public async getUserTasksForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.UserTasks.UserTaskList> {
+    this._ensureIsAuthorized(identity);
+
     return this.consumerApiAccessor.getUserTasksForProcessModel(identity, processModelId);
   }
 
   public async getUserTasksForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.UserTasks.UserTaskList> {
+    this._ensureIsAuthorized(identity);
+
     return this.consumerApiAccessor.getUserTasksForCorrelation(identity, correlationId);
   }
 
-  public async getUserTasksForProcessModelInCorrelation(identity: IIdentity,
-                                                        processModelId: string,
-                                                        correlationId: string): Promise<DataModels.UserTasks.UserTaskList> {
+  public async getUserTasksForProcessModelInCorrelation(
+    identity: IIdentity,
+    processModelId: string,
+    correlationId: string,
+  ): Promise<DataModels.UserTasks.UserTaskList> {
+    this._ensureIsAuthorized(identity);
 
     return this.consumerApiAccessor.getUserTasksForProcessModelInCorrelation(identity, processModelId, correlationId);
   }
@@ -219,35 +270,55 @@ export class ConsumerApiClientService implements IConsumerApi {
     userTaskInstanceId: string,
     userTaskResult: DataModels.UserTasks.UserTaskResult,
   ): Promise<void> {
+    this._ensureIsAuthorized(identity);
 
     return this.consumerApiAccessor.finishUserTask(identity, processInstanceId, correlationId, userTaskInstanceId, userTaskResult);
   }
 
   // ManualTasks
   public async getManualTasksForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
+    this._ensureIsAuthorized(identity);
+
     return this.consumerApiAccessor.getManualTasksForProcessModel(identity, processModelId);
   }
 
   public async getManualTasksForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
+    this._ensureIsAuthorized(identity);
+
     return this.consumerApiAccessor.getManualTasksForCorrelation(identity, correlationId);
   }
 
-  public async getManualTasksForProcessModelInCorrelation(identity: IIdentity,
-                                                          processModelId: string,
-                                                          correlationId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
+  public async getManualTasksForProcessModelInCorrelation(
+    identity: IIdentity,
+    processModelId: string,
+    correlationId: string,
+  ): Promise<DataModels.ManualTasks.ManualTaskList> {
+    this._ensureIsAuthorized(identity);
 
     return this.consumerApiAccessor.getManualTasksForProcessModelInCorrelation(identity, processModelId, correlationId);
   }
 
   public async getWaitingManualTasksByIdentity(identity: IIdentity): Promise<DataModels.ManualTasks.ManualTaskList> {
+    this._ensureIsAuthorized(identity);
+
     return this.consumerApiAccessor.getWaitingManualTasksByIdentity(identity);
   }
 
-  public async finishManualTask(identity: IIdentity,
-                                processInstanceId: string,
-                                correlationId: string,
-                                manualTaskInstanceId: string): Promise<void> {
+  public async finishManualTask(
+    identity: IIdentity,
+    processInstanceId: string,
+    correlationId: string,
+    manualTaskInstanceId: string,
+  ): Promise<void> {
+    this._ensureIsAuthorized(identity);
 
-  return this.consumerApiAccessor.finishManualTask(identity, processInstanceId, correlationId, manualTaskInstanceId);
+    return this.consumerApiAccessor.finishManualTask(identity, processInstanceId, correlationId, manualTaskInstanceId);
+  }
+
+  private _ensureIsAuthorized(identity: IIdentity): void {
+    const noAuthTokenProvided: boolean = !identity || typeof identity.token !== 'string';
+    if (noAuthTokenProvided) {
+      throw new EssentialProjectErrors.UnauthorizedError('No auth token provided!');
+    }
   }
 }

--- a/typescript/src/consumer_api_client_service.ts
+++ b/typescript/src/consumer_api_client_service.ts
@@ -79,6 +79,10 @@ export class ConsumerApiClientService implements IConsumerApi {
     return this.consumerApiAccessor.onProcessEnded(identity, callback);
   }
 
+  public async removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void> {
+    return this.consumerApiAccessor.removeSubscription(identity, subscription);
+  }
+
   // Process models and instances
   public async getProcessModels(identity: IIdentity): Promise<DataModels.ProcessModels.ProcessModelList> {
     return this.consumerApiAccessor.getProcessModels(identity);

--- a/typescript/src/consumer_api_client_service.ts
+++ b/typescript/src/consumer_api_client_service.ts
@@ -18,65 +18,101 @@ export class ConsumerApiClientService implements IConsumerApi {
   }
 
   // Notifications
-  public async onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<Subscription> {
-    return this.consumerApiAccessor.onUserTaskWaiting(identity, callback);
+  public async onUserTaskWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.consumerApiAccessor.onUserTaskWaiting(identity, callback, subscribeOnce);
   }
 
-  public async onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Promise<Subscription> {
-    return this.consumerApiAccessor.onUserTaskFinished(identity, callback);
+  public async onUserTaskFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.consumerApiAccessor.onUserTaskFinished(identity, callback, subscribeOnce);
   }
 
-  public async onUserTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<Subscription> {
-    return this.consumerApiAccessor.onUserTaskForIdentityWaiting(identity, callback);
+  public async onUserTaskForIdentityWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.consumerApiAccessor.onUserTaskForIdentityWaiting(identity, callback, subscribeOnce);
   }
 
   public async onUserTaskForIdentityFinished(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
+    subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    return this.consumerApiAccessor.onUserTaskForIdentityFinished(identity, callback);
+    return this.consumerApiAccessor.onUserTaskForIdentityFinished(identity, callback, subscribeOnce);
   }
 
-  public async onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): Promise<Subscription> {
-    return this.consumerApiAccessor.onProcessTerminated(identity, callback);
+  public async onProcessTerminated(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnProcessTerminatedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.consumerApiAccessor.onProcessTerminated(identity, callback, subscribeOnce);
   }
 
-  public async onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): Promise<Subscription> {
-    return this.consumerApiAccessor.onProcessStarted(identity, callback);
+  public async onProcessStarted(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnProcessStartedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.consumerApiAccessor.onProcessStarted(identity, callback, subscribeOnce);
   }
 
   public async onProcessWithProcessModelIdStarted(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnProcessStartedCallback,
     processModelId: string,
+    subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    return this.consumerApiAccessor.onProcessWithProcessModelIdStarted(identity, callback, processModelId);
+    return this.consumerApiAccessor.onProcessWithProcessModelIdStarted(identity, callback, processModelId, subscribeOnce);
   }
 
-  public async onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Promise<Subscription> {
-    return this.consumerApiAccessor.onManualTaskWaiting(identity, callback);
+  public async onManualTaskWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.consumerApiAccessor.onManualTaskWaiting(identity, callback, subscribeOnce);
   }
 
-  public async onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Promise<Subscription> {
-    return this.consumerApiAccessor.onManualTaskFinished(identity, callback);
+  public async onManualTaskFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.consumerApiAccessor.onManualTaskFinished(identity, callback, subscribeOnce);
   }
 
   public async onManualTaskForIdentityWaiting(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
+    subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    return this.consumerApiAccessor.onManualTaskForIdentityWaiting(identity, callback);
+    return this.consumerApiAccessor.onManualTaskForIdentityWaiting(identity, callback, subscribeOnce);
   }
 
   public async onManualTaskForIdentityFinished(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
+    subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    return this.consumerApiAccessor.onManualTaskForIdentityFinished(identity, callback);
+    return this.consumerApiAccessor.onManualTaskForIdentityFinished(identity, callback, subscribeOnce);
   }
 
-  public async onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): Promise<Subscription> {
-    return this.consumerApiAccessor.onProcessEnded(identity, callback);
+  public async onProcessEnded(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnProcessEndedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.consumerApiAccessor.onProcessEnded(identity, callback, subscribeOnce);
   }
 
   public async removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void> {

--- a/typescript/src/consumer_api_client_service.ts
+++ b/typescript/src/consumer_api_client_service.ts
@@ -260,6 +260,8 @@ export class ConsumerApiClientService implements IConsumerApi {
   }
 
   public async getWaitingUserTasksByIdentity(identity: IIdentity): Promise<DataModels.UserTasks.UserTaskList> {
+    this._ensureIsAuthorized(identity);
+
     return this.consumerApiAccessor.getWaitingUserTasksByIdentity(identity);
   }
 


### PR DESCRIPTION
**Changes:**

1. Implement the `removeSubscription` UseCase, which allows a user to unsubscribe from a notification.
2. Implement the `disconnectSocket` function into the ExternalAccessor, which allows a user to close a Socket.IO client.
3. Implement `subscribeOnce` flag for all notification Subscriptions. This works pretty much like the `subscribeOnce` UseCase for the EventAggregator.
4. The ExternalAccessor should no longer permit to connect to Socket.IO, if the user does not provide an identity.
5. Refactor all Notification subscription functions so that they return the created subscriptions.
6. Move all Auth-Checks from the accessors to the client to avoid code duplication.

**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/#135
Part of https://github.com/process-engine/process_engine_runtime/issues/#157
Part of https://github.com/process-engine/process_engine_runtime/issues/#206

PR: #32

## How can others test the changes?

- Create a client that uses the external accessor
- Create some subscriptions for notifications
- Trigger these notifications to receive them
- Unsubscribe from a notification
- Trigger the notification again
- Notice that the callback you provided for that notification will no longer get triggered
- Dispose the ExternalAccessor
- The Socket.IO client will have disconnected from the server and is no longer able to receive notifications

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).