### PR TITLE
♻️⚡️ Allow multiple Socket.io connections for the same accessor

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/consumer_api_client",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "the api-client package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/typescript/src/accessors/external_accessor.ts
+++ b/typescript/src/accessors/external_accessor.ts
@@ -17,25 +17,24 @@ import {
 } from '@process-engine/consumer_api_contracts';
 
 /**
+ * Associates a Socket with a userId taken from an IIdentity.
+ */
+type IdentitySocketCollection = {[userId: string]: SocketIOClient.Socket};
+
+/**
  * Connects a Subscription ID to a specific callback.
  * This allows us to remove that Subscription from SocketIO
  * when "ExternalAccessor.removeSubscription" is called.
  */
 type SubscriptionCallbackAssociation = {[subscriptionId: string]: any};
 
-/**
- * Associates a Socket with a userId taken from an IIdentity.
- */
-type IdentitySocketCollection = {[userId: string]: SocketIOClient.Socket};
-
 export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIoAccessor {
   private baseUrl: string = 'api/consumer/v1';
 
+  private _socketCollection: IdentitySocketCollection = {};
   private _subscriptionCollection: SubscriptionCallbackAssociation = {};
 
   private _httpClient: IHttpClient = undefined;
-
-  private _socketCollection: IdentitySocketCollection = {};
 
   public config: any;
 


### PR DESCRIPTION
**Changes:**

1. Refactor the ExternalAccessor to automatically create `Socket.io` connections for each identity.
2. A convention call to `initializeSocket` upon starting the client is no longer necessary. The method only remains as a convenience function, in case you want to use the client for only one identity.

PR: #38

## How can others test the changes?

- Try using the same client with multiple identities. 
- Each identity should now automatically get its own `Socket.io` connection.
- Calling `initializeSocket` manually should no longer be necessary.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).