### PR TITLE
♻️ Make the StartEventId Parameter Optional 

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -22,7 +22,7 @@
     "@essential-projects/errors_ts": "^1.4.0",
     "@essential-projects/http_contracts": "^2.3.0",
     "@essential-projects/iam_contracts": "^3.4.0",
-    "@process-engine/consumer_api_contracts": "feature~optional_start_event_id",
+    "@process-engine/consumer_api_contracts": "^5.0.0",
     "async-middleware": "^1.2.1",
     "bluebird": "^3.5.3",
     "loggerhythm": "^3.0.3",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -22,7 +22,7 @@
     "@essential-projects/errors_ts": "^1.4.0",
     "@essential-projects/http_contracts": "^2.3.0",
     "@essential-projects/iam_contracts": "^3.4.0",
-    "@process-engine/consumer_api_contracts": "^4.1.0",
+    "@process-engine/consumer_api_contracts": "feature~optional_start_event_id",
     "async-middleware": "^1.2.1",
     "bluebird": "^3.5.3",
     "loggerhythm": "^3.0.3",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/consumer_api_client",
-  "version": "3.2.2",
+  "version": "4.0.0",
   "description": "the api-client package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/typescript/src/accessors/external_accessor.ts
+++ b/typescript/src/accessors/external_accessor.ts
@@ -221,9 +221,9 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
   public async startProcessInstance(
     identity: IIdentity,
     processModelId: string,
-    startEventId: string,
     payload: DataModels.ProcessModels.ProcessStartRequestPayload,
     startCallbackType: DataModels.ProcessModels.StartCallbackType,
+    startEventId?: string,
     endEventId?: string,
     processEndedCallback?: Messages.CallbackTypes.OnProcessEndedCallback,
   ): Promise<DataModels.ProcessModels.ProcessStartResponsePayload> {

--- a/typescript/src/accessors/external_accessor.ts
+++ b/typescript/src/accessors/external_accessor.ts
@@ -228,7 +228,7 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     processEndedCallback?: Messages.CallbackTypes.OnProcessEndedCallback,
   ): Promise<DataModels.ProcessModels.ProcessStartResponsePayload> {
 
-    const url: string = this._buildStartProcessInstanceUrl(processModelId, startEventId, startCallbackType, endEventId);
+    const url: string = this._buildStartProcessInstanceUrl(processModelId, startCallbackType, endEventId, startEventId);
 
     const requestAuthHeaders: IRequestOptions = this._createRequestAuthHeaders(identity);
 
@@ -249,15 +249,19 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
 
   private _buildStartProcessInstanceUrl(
     processModelId: string,
-    startEventId: string,
     startCallbackType: DataModels.ProcessModels.StartCallbackType,
     endEventId: string,
+    startEventId?: string,
   ): string {
     let url: string = restSettings.paths.startProcessInstance
-      .replace(restSettings.params.processModelId, processModelId)
-      .replace(restSettings.params.startEventId, startEventId);
+      .replace(restSettings.params.processModelId, processModelId);
 
     url = `${url}?start_callback_type=${startCallbackType}`;
+
+    const startEventIdIsGiven: boolean = startEventId !== undefined;
+    if (startEventIdIsGiven) {
+      url = `${url}&start_event_id=${startEventId}`;
+    }
 
     const attachEndEventId: boolean = startCallbackType === DataModels.ProcessModels.StartCallbackType.CallbackOnEndEventReached;
     if (attachEndEventId) {

--- a/typescript/src/accessors/internal_accessor.ts
+++ b/typescript/src/accessors/internal_accessor.ts
@@ -134,9 +134,9 @@ export class InternalAccessor implements IConsumerApiAccessor {
   public async startProcessInstance(
     identity: IIdentity,
     processModelId: string,
-    startEventId: string,
     payload: DataModels.ProcessModels.ProcessStartRequestPayload,
     startCallbackType?: DataModels.ProcessModels.StartCallbackType,
+    startEventId?: string,
     endEventId?: string,
   ): Promise<DataModels.ProcessModels.ProcessStartResponsePayload> {
 

--- a/typescript/src/accessors/internal_accessor.ts
+++ b/typescript/src/accessors/internal_accessor.ts
@@ -140,7 +140,7 @@ export class InternalAccessor implements IConsumerApiAccessor {
     endEventId?: string,
   ): Promise<DataModels.ProcessModels.ProcessStartResponsePayload> {
 
-    return this._consumerApiService.startProcessInstance(identity, processModelId, startEventId, payload, startCallbackType, endEventId);
+    return this._consumerApiService.startProcessInstance(identity, processModelId, payload, startCallbackType, startEventId, endEventId);
   }
 
   public async getProcessResultForCorrelation(

--- a/typescript/src/consumer_api_client_service.ts
+++ b/typescript/src/consumer_api_client_service.ts
@@ -166,9 +166,9 @@ export class ConsumerApiClientService implements IConsumerApi {
 
   public async startProcessInstance(identity: IIdentity,
                                     processModelId: string,
-                                    startEventId: string,
                                     payload: DataModels.ProcessModels.ProcessStartRequestPayload,
                                     startCallbackType?: DataModels.ProcessModels.StartCallbackType,
+                                    startEventId?: string,
                                     endEventId?: string,
                                   ): Promise<DataModels.ProcessModels.ProcessStartResponsePayload> {
     this._ensureIsAuthorized(identity);

--- a/typescript/src/consumer_api_client_service.ts
+++ b/typescript/src/consumer_api_client_service.ts
@@ -188,7 +188,7 @@ export class ConsumerApiClientService implements IConsumerApi {
       throw new EssentialProjectErrors.BadRequestError(`Must provide an EndEventId, when using callback type 'CallbackOnEndEventReached'!`);
     }
 
-    return this.consumerApiAccessor.startProcessInstance(identity, processModelId, startEventId, payload, startCallbackType, endEventId);
+    return this.consumerApiAccessor.startProcessInstance(identity, processModelId, payload, startCallbackType, startEventId, endEventId);
   }
 
   public async getProcessResultForCorrelation(


### PR DESCRIPTION
**Changes:**

1. Makes the StartEventId Parameter on the `startProcessInstance` Method optional.
This is a breaking change, because the public methods of the client and its accessors have been changed.

**Issues:**

Related: https://github.com/process-engine/process_engine_runtime/issues/252

PR: #39

## How can others test the changes?

Use the client to start new ProcessInstances, without providing a StartEventId.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).