### PR TITLE
✨ Implement .NET ManualTaskConsumer API

### DIFF
--- a/dotnet/src/ConsumerApiClientService.cs
+++ b/dotnet/src/ConsumerApiClientService.cs
@@ -15,7 +15,8 @@
 
     using Newtonsoft.Json.Serialization;
     using Newtonsoft.Json;
-    using ProcessEngine.ConsumerAPI.Contracts.Messages.SystemEvent;
+    using ProcessEngine.ConsumerAPI.Contracts.APIs;
+    using ProcessEngine.ConsumerAPI.Contracts.DataModel;
 
     public class ConsumerApiClientService : IConsumerAPI
     {
@@ -262,6 +263,11 @@
             return message;
         }
 
+        Task<IEnumerable<CorrelationResult<TPayload>>> IProcessModelConsumerApi.GetProcessResultForCorrelation<TPayload>(IIdentity identity, string correlationId, string processModelId)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task<UserTaskList> GetUserTasksForProcessModel(IIdentity identity, string processModelId)
         {
             throw new NotImplementedException();
@@ -292,22 +298,122 @@
             throw new NotImplementedException();
         }
 
-        public IDisposable OnUserTaskWaiting(IIdentity identity, Action<UserTaskReachedMessage> callback, bool? subscribeOnce)
+        public async Task<ManualTaskList> GetManualTasksForProcessModel(IIdentity identity, string processModelId)
         {
-            throw new NotImplementedException();
+            var url = RestSettings.Paths.ProcessModelManualTasks
+                .Replace(RestSettings.Params.ProcessModelId, processModelId);
+
+            url = $"{RestSettings.Endpoints.ConsumerAPI}{url}";
+
+            var jsonResult = "";
+
+            ManualTaskList parsedResult = null;
+
+            var request = this.CreateRequestMessage(identity, HttpMethod.Get, url);
+            var result = await this.httpClient.SendAsync(request);
+
+            if (result.IsSuccessStatusCode)
+            {
+                jsonResult = await result.Content.ReadAsStringAsync();
+                parsedResult = JsonConvert.DeserializeObject<ManualTaskList>(jsonResult);
+            }
+
+            return parsedResult;
         }
 
-        public IDisposable OnUserTaskFinished(IIdentity identity, Action<UserTaskFinishedMessage> callback, bool? subscribeOnce)
+        public async Task<ManualTaskList> GetManualTasksForProcessInstance(IIdentity identity, string processInstanceId)
         {
-            throw new NotImplementedException();
+            var url = RestSettings.Paths.ProcessInstanceManualTasks
+                .Replace(RestSettings.Params.ProcessInstanceId, processInstanceId);
+
+            url = $"{RestSettings.Endpoints.ConsumerAPI}{url}";
+
+            var jsonResult = "";
+
+            ManualTaskList parsedResult = null;
+
+            var request = this.CreateRequestMessage(identity, HttpMethod.Get, url);
+            var result = await this.httpClient.SendAsync(request);
+
+            if (result.IsSuccessStatusCode)
+            {
+                jsonResult = await result.Content.ReadAsStringAsync();
+                parsedResult = JsonConvert.DeserializeObject<ManualTaskList>(jsonResult);
+            }
+
+            return parsedResult;
         }
 
-        public IDisposable OnUserTaskForIdentityWaiting(IIdentity identity, Action<UserTaskReachedMessage> callback, bool? subscribeOnce)
+        public async Task<ManualTaskList> GetManualTasksForCorrelation(IIdentity identity, string correlationId)
         {
-            throw new NotImplementedException();
+            var url = RestSettings.Paths.CorrelationManualTasks
+                .Replace(RestSettings.Params.CorrelationId, correlationId);
+
+            url = $"{RestSettings.Endpoints.ConsumerAPI}{url}";
+
+            var jsonResult = "";
+
+            ManualTaskList parsedResult = null;
+
+            var request = this.CreateRequestMessage(identity, HttpMethod.Get, url);
+            var result = await this.httpClient.SendAsync(request);
+
+            if (result.IsSuccessStatusCode)
+            {
+                jsonResult = await result.Content.ReadAsStringAsync();
+                parsedResult = JsonConvert.DeserializeObject<ManualTaskList>(jsonResult);
+            }
+
+            return parsedResult;
         }
 
-        public IDisposable OnUserTaskForIdentityFinished(IIdentity identity, Action<UserTaskFinishedMessage> callback, bool? subscribeOnce)
+        public async Task<ManualTaskList> GetManualTasksForProcessModelInCorrelation(IIdentity identity, string processModelId, string correlationId)
+        {
+            var url = RestSettings.Paths.ProcessModelCorrelationManualTasks
+                .Replace(RestSettings.Params.ProcessModelId, processModelId)
+                .Replace(RestSettings.Params.CorrelationId, correlationId);
+
+            url = $"{RestSettings.Endpoints.ConsumerAPI}{url}";
+
+            var jsonResult = "";
+
+            ManualTaskList parsedResult = null;
+
+            var request = this.CreateRequestMessage(identity, HttpMethod.Get, url);
+            var result = await this.httpClient.SendAsync(request);
+
+            if (result.IsSuccessStatusCode)
+            {
+                jsonResult = await result.Content.ReadAsStringAsync();
+                parsedResult = JsonConvert.DeserializeObject<ManualTaskList>(jsonResult);
+            }
+
+            return parsedResult;
+        }
+
+        public async Task<ManualTaskList> GetWaitingManualTasksByIdentity(IIdentity identity)
+        {
+            var url = RestSettings.Paths.GetOwnManualTasks;
+
+            url = $"{RestSettings.Endpoints.ConsumerAPI}{url}";
+
+            var jsonResult = "";
+
+            ManualTaskList parsedResult = null;
+
+            var request = this.CreateRequestMessage(identity, HttpMethod.Get, url);
+            var result = await this.httpClient.SendAsync(request);
+
+            if (result.IsSuccessStatusCode)
+            {
+                jsonResult = await result.Content.ReadAsStringAsync();
+                parsedResult = JsonConvert.DeserializeObject<ManualTaskList>(jsonResult);
+            }
+
+            return parsedResult;
+        }
+
+        public Task FinishManualTask(IIdentity identity, string processInstanceId, string correlationId, string manualTaskInstanceId)
         {
             throw new NotImplementedException();
         }

--- a/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
+++ b/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="10.0.0-feature-add-manual-task-consumer-api" />
+    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="10.0.0-develop" />
     <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
   </ItemGroup>
 

--- a/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
+++ b/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="9.1.0-feature-add-manual-task-consumer-api" />
+    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="10.0.0-feature-add-manual-task-consumer-api" />
     <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
   </ItemGroup>
 

--- a/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
+++ b/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="9.0.0-feature-enhance-user-task-api" />
+    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="9.1.0-feature-add-manual-task-consumer-api" />
     <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
   </ItemGroup>
 

--- a/dotnet/tests/ConsumerAPIService/GetEventsForCorrelationTests.cs
+++ b/dotnet/tests/ConsumerAPIService/GetEventsForCorrelationTests.cs
@@ -27,24 +27,22 @@ namespace ProcessEngine.ConsumerAPI.Client.Tests
         [Fact]
         public async Task BPMN_GetEventsForCorrelationTests_ShouldFetchEventsOfRunningProcess()
         {
-            var identity = DummyIdentity.Create();
-            string processModelId = "test_consumer_api_message_event";
-            string messageName = "test_message_event";
+            var processModelId = "test_consumer_api_message_event";
+            var messageName = "test_message_event";
 
             var requestPayload = new ProcessStartRequestPayload<object>();
 
-            ProcessStartResponsePayload processStartResponsePayload = await this.fixture.ConsumerAPIClient.StartProcessInstance(
-                identity,
-                processModelId,
-                "StartEvent_1",
-                requestPayload);
+            ProcessStartResponsePayload processStartResponsePayload = await this
+                .fixture
+                .ConsumerAPIClient
+                .StartProcessInstance(this.fixture.DefaultIdentity, processModelId, "StartEvent_1", requestPayload);
 
             await Task.Delay(1000);
 
-            var events = await this.fixture.ConsumerAPIClient.GetEventsForCorrelation(
-                identity,
-                processStartResponsePayload.CorrelationId
-            );
+            var events = await this
+                .fixture
+                .ConsumerAPIClient
+                .GetEventsForCorrelation(this.fixture.DefaultIdentity, processStartResponsePayload.CorrelationId);
 
             Assert.NotEmpty(events.Events);
 

--- a/dotnet/tests/ConsumerAPIService/GetEventsForProcessModelInCorrelationTests.cs
+++ b/dotnet/tests/ConsumerAPIService/GetEventsForProcessModelInCorrelationTests.cs
@@ -27,25 +27,22 @@ namespace ProcessEngine.ConsumerAPI.Client.Tests
         [Fact]
         public async Task BPMN_GetEventsForProcessModelInCorrelation_ShouldFetchEventsOfRunningProcess()
         {
-            var identity = DummyIdentity.Create();
-            string processModelId = "test_consumer_api_message_event";
-            string messageName = "test_message_event";
+            var processModelId = "test_consumer_api_message_event";
+            var messageName = "test_message_event";
 
             var requestPayload = new ProcessStartRequestPayload<object>();
 
-            ProcessStartResponsePayload processStartResponsePayload = await this.fixture.ConsumerAPIClient.StartProcessInstance(
-                identity,
-                processModelId,
-                "StartEvent_1",
-                requestPayload);
+            ProcessStartResponsePayload processStartResponsePayload = await this
+                .fixture
+                .ConsumerAPIClient
+                .StartProcessInstance(this.fixture.DefaultIdentity, processModelId, "StartEvent_1", requestPayload);
 
             await Task.Delay(1000);
 
-            var events = await this.fixture.ConsumerAPIClient.GetEventsForProcessModelInCorrelation(
-                identity,
-                processModelId,
-                processStartResponsePayload.CorrelationId
-            );
+            var events = await this
+                .fixture
+                .ConsumerAPIClient
+                .GetEventsForProcessModelInCorrelation(this.fixture.DefaultIdentity, processModelId, processStartResponsePayload.CorrelationId);
 
             Assert.NotEmpty(events.Events);
 

--- a/dotnet/tests/ConsumerAPIService/GetEventsForProcessModelTests.cs
+++ b/dotnet/tests/ConsumerAPIService/GetEventsForProcessModelTests.cs
@@ -27,24 +27,22 @@ namespace ProcessEngine.ConsumerAPI.Client.Tests
         [Fact]
         public async Task BPMN_GetEventsForCorrelationTests_ShouldFetchEventsOfRunningProcess()
         {
-            var identity = DummyIdentity.Create();
-            string processModelId = "test_consumer_api_message_event";
-            string messageName = "test_message_event";
+            var processModelId = "test_consumer_api_message_event";
+            var messageName = "test_message_event";
 
             var requestPayload = new ProcessStartRequestPayload<object>();
 
-            ProcessStartResponsePayload processStartResponsePayload = await this.fixture.ConsumerAPIClient.StartProcessInstance(
-                identity,
-                processModelId,
-                "StartEvent_1",
-                requestPayload);
+            ProcessStartResponsePayload processStartResponsePayload = await this
+                .fixture
+                .ConsumerAPIClient
+                .StartProcessInstance(this.fixture.DefaultIdentity, processModelId, "StartEvent_1", requestPayload);
 
             await Task.Delay(1000);
 
-            var events = await this.fixture.ConsumerAPIClient.GetEventsForProcessModel(
-                identity,
-                processModelId
-            );
+            var events = await this
+                .fixture
+                .ConsumerAPIClient
+                .GetEventsForProcessModel(this.fixture.DefaultIdentity, processModelId);
 
             Assert.NotEmpty(events.Events);
 

--- a/dotnet/tests/ConsumerAPIService/GetManualTasksForProcessInstanceTests.cs
+++ b/dotnet/tests/ConsumerAPIService/GetManualTasksForProcessInstanceTests.cs
@@ -28,22 +28,22 @@ namespace ProcessEngine.ConsumerAPI.Client.Tests
         [Fact]
         public async Task BPMN_GetManualTasksForProcessInstance_ShouldFetchManualTaskList()
         {
-            string processModelId = "test_consumer_api_manualtask";
-            var identity = DummyIdentity.Create();
+            var processModelId = "test_consumer_api_manualtask";
+            var payload = new ProcessStartRequestPayload<object>();
+            var callbackType = StartCallbackType.CallbackOnProcessInstanceCreated;
 
-            ProcessStartResponsePayload processInstance = await this.fixture.ConsumerAPIClient.StartProcessInstance(
-                identity,
-                processModelId,
-                "StartEvent_1",
-                new ProcessStartRequestPayload<object>(),
-                StartCallbackType.CallbackOnProcessInstanceCreated);
+            ProcessStartResponsePayload processInstance = await this
+                .fixture
+                .ConsumerAPIClient
+                .StartProcessInstance(this.fixture.DefaultIdentity, processModelId, "StartEvent_1", payload, callbackType);
 
             // Give the process engine time to reach the user task
             await Task.Delay(1000);
 
-            ManualTaskList manualTasks = await this.fixture.ConsumerAPIClient.GetManualTasksForProcessInstance(
-                identity,
-                processInstance.ProcessInstanceId);
+            ManualTaskList manualTasks = await this
+                .fixture
+                .ConsumerAPIClient
+                .GetManualTasksForProcessInstance(this.fixture.DefaultIdentity, processInstance.ProcessInstanceId);
 
             Assert.NotEmpty(manualTasks.ManualTasks);
         }

--- a/dotnet/tests/ConsumerAPIService/GetManualTasksForProcessInstanceTests.cs
+++ b/dotnet/tests/ConsumerAPIService/GetManualTasksForProcessInstanceTests.cs
@@ -1,0 +1,52 @@
+namespace ProcessEngine.ConsumerAPI.Client.Tests
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System;
+    using System.Threading;
+
+    using EssentialProjects.IAM.Contracts;
+
+    using ProcessEngine.ConsumerAPI.Client.Tests.xUnit;
+    using ProcessEngine.ConsumerAPI.Contracts.DataModel;
+    using ProcessEngine.ConsumerAPI.Contracts;
+
+    using Xunit;
+
+    [Collection("ConsumerAPI collection")]
+    public class GetManualTasksForProcessInstanceTests : ProcessEngineBaseTest
+    {
+        private readonly ConsumerAPIFixture fixture;
+
+        public GetManualTasksForProcessInstanceTests(ConsumerAPIFixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact]
+        public async Task BPMN_GetManualTasksForProcessInstance_ShouldFetchManualTaskList()
+        {
+            string processModelId = "test_consumer_api_manualtask";
+            var identity = DummyIdentity.Create();
+
+            ProcessStartResponsePayload processInstance = await this.fixture.ConsumerAPIClient.StartProcessInstance(
+                identity,
+                processModelId,
+                "StartEvent_1",
+                new ProcessStartRequestPayload<object>(),
+                StartCallbackType.CallbackOnProcessInstanceCreated);
+
+            // Give the process engine time to reach the user task
+            await Task.Delay(1000);
+
+            ManualTaskList manualTasks = await this.fixture.ConsumerAPIClient.GetManualTasksForProcessInstance(
+                identity,
+                processInstance.ProcessInstanceId);
+
+            Assert.NotEmpty(manualTasks.ManualTasks);
+        }
+
+    }
+}

--- a/dotnet/tests/ConsumerAPIService/GetManualTasksForProcessModelInCorrelationTests.cs
+++ b/dotnet/tests/ConsumerAPIService/GetManualTasksForProcessModelInCorrelationTests.cs
@@ -1,0 +1,53 @@
+namespace ProcessEngine.ConsumerAPI.Client.Tests
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System;
+    using System.Threading;
+
+    using EssentialProjects.IAM.Contracts;
+
+    using ProcessEngine.ConsumerAPI.Client.Tests.xUnit;
+    using ProcessEngine.ConsumerAPI.Contracts.DataModel;
+    using ProcessEngine.ConsumerAPI.Contracts;
+
+    using Xunit;
+
+    [Collection("ConsumerAPI collection")]
+    public class GetManualTasksForProcessModelInCorrelationTests : ProcessEngineBaseTest
+    {
+        private readonly ConsumerAPIFixture fixture;
+
+        public GetManualTasksForProcessModelInCorrelationTests(ConsumerAPIFixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact]
+        public async Task BPMN_GetManualTasksForProcessModelInCorrelation_ShouldFetchManualTaskList()
+        {
+            string processModelId = "test_consumer_api_manualtask";
+            var identity = DummyIdentity.Create();
+
+            ProcessStartResponsePayload processInstance = await this.fixture.ConsumerAPIClient.StartProcessInstance(
+                identity,
+                processModelId,
+                "StartEvent_1",
+                new ProcessStartRequestPayload<object>(),
+                StartCallbackType.CallbackOnProcessInstanceCreated);
+
+            // Give the process engine time to reach the user task
+            await Task.Delay(1000);
+
+            ManualTaskList manualTasks = await this.fixture.ConsumerAPIClient.GetManualTasksForProcessModelInCorrelation(
+                identity,
+                processModelId,
+                processInstance.CorrelationId);
+
+            Assert.NotEmpty(manualTasks.ManualTasks);
+        }
+
+    }
+}

--- a/dotnet/tests/ConsumerAPIService/GetManualTasksForProcessModelInCorrelationTests.cs
+++ b/dotnet/tests/ConsumerAPIService/GetManualTasksForProcessModelInCorrelationTests.cs
@@ -28,23 +28,22 @@ namespace ProcessEngine.ConsumerAPI.Client.Tests
         [Fact]
         public async Task BPMN_GetManualTasksForProcessModelInCorrelation_ShouldFetchManualTaskList()
         {
-            string processModelId = "test_consumer_api_manualtask";
-            var identity = DummyIdentity.Create();
+            var processModelId = "test_consumer_api_manualtask";
+            var payload = new ProcessStartRequestPayload<object>();
+            var callbackType = StartCallbackType.CallbackOnProcessInstanceCreated;
 
-            ProcessStartResponsePayload processInstance = await this.fixture.ConsumerAPIClient.StartProcessInstance(
-                identity,
-                processModelId,
-                "StartEvent_1",
-                new ProcessStartRequestPayload<object>(),
-                StartCallbackType.CallbackOnProcessInstanceCreated);
+            ProcessStartResponsePayload processInstance = await this
+                .fixture
+                .ConsumerAPIClient
+                .StartProcessInstance(this.fixture.DefaultIdentity, processModelId, "StartEvent_1", payload, callbackType);
 
             // Give the process engine time to reach the user task
             await Task.Delay(1000);
 
-            ManualTaskList manualTasks = await this.fixture.ConsumerAPIClient.GetManualTasksForProcessModelInCorrelation(
-                identity,
-                processModelId,
-                processInstance.CorrelationId);
+            ManualTaskList manualTasks = await this
+                .fixture
+                .ConsumerAPIClient
+                .GetManualTasksForProcessModelInCorrelation(this.fixture.DefaultIdentity, processModelId, processInstance.CorrelationId);
 
             Assert.NotEmpty(manualTasks.ManualTasks);
         }

--- a/dotnet/tests/ConsumerAPIService/GetManualTasksForProcessModelTests.cs
+++ b/dotnet/tests/ConsumerAPIService/GetManualTasksForProcessModelTests.cs
@@ -28,22 +28,22 @@ namespace ProcessEngine.ConsumerAPI.Client.Tests
         [Fact]
         public async Task BPMN_GetManualTasksForProcessModel_ShouldFetchManualTaskList()
         {
-            string processModelId = "test_consumer_api_manualtask";
-            var identity = DummyIdentity.Create();
+            var processModelId = "test_consumer_api_manualtask";
+            var payload = new ProcessStartRequestPayload<object>();
+            var callbackType = StartCallbackType.CallbackOnProcessInstanceCreated;
 
-            ProcessStartResponsePayload processInstance = await this.fixture.ConsumerAPIClient.StartProcessInstance(
-                identity,
-                processModelId,
-                "StartEvent_1",
-                new ProcessStartRequestPayload<object>(),
-                StartCallbackType.CallbackOnProcessInstanceCreated);
+            ProcessStartResponsePayload processInstance = await this
+                .fixture
+                .ConsumerAPIClient
+                .StartProcessInstance(this.fixture.DefaultIdentity, processModelId, "StartEvent_1", payload, callbackType);
 
             // Give the process engine time to reach the user task
             await Task.Delay(1000);
 
-            ManualTaskList manualTasks = await this.fixture.ConsumerAPIClient.GetManualTasksForProcessModel(
-                identity,
-                processModelId);
+            ManualTaskList manualTasks = await this
+                .fixture
+                .ConsumerAPIClient
+                .GetManualTasksForProcessModel(this.fixture.DefaultIdentity, processModelId);
 
             Assert.NotEmpty(manualTasks.ManualTasks);
         }

--- a/dotnet/tests/ConsumerAPIService/GetManualTasksForProcessModelTests.cs
+++ b/dotnet/tests/ConsumerAPIService/GetManualTasksForProcessModelTests.cs
@@ -1,0 +1,52 @@
+namespace ProcessEngine.ConsumerAPI.Client.Tests
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System;
+    using System.Threading;
+
+    using EssentialProjects.IAM.Contracts;
+
+    using ProcessEngine.ConsumerAPI.Client.Tests.xUnit;
+    using ProcessEngine.ConsumerAPI.Contracts.DataModel;
+    using ProcessEngine.ConsumerAPI.Contracts;
+
+    using Xunit;
+
+    [Collection("ConsumerAPI collection")]
+    public class GetManualTasksForProcessModelTests : ProcessEngineBaseTest
+    {
+        private readonly ConsumerAPIFixture fixture;
+
+        public GetManualTasksForProcessModelTests(ConsumerAPIFixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact]
+        public async Task BPMN_GetManualTasksForProcessModel_ShouldFetchManualTaskList()
+        {
+            string processModelId = "test_consumer_api_manualtask";
+            var identity = DummyIdentity.Create();
+
+            ProcessStartResponsePayload processInstance = await this.fixture.ConsumerAPIClient.StartProcessInstance(
+                identity,
+                processModelId,
+                "StartEvent_1",
+                new ProcessStartRequestPayload<object>(),
+                StartCallbackType.CallbackOnProcessInstanceCreated);
+
+            // Give the process engine time to reach the user task
+            await Task.Delay(1000);
+
+            ManualTaskList manualTasks = await this.fixture.ConsumerAPIClient.GetManualTasksForProcessModel(
+                identity,
+                processModelId);
+
+            Assert.NotEmpty(manualTasks.ManualTasks);
+        }
+
+    }
+}

--- a/dotnet/tests/ConsumerAPIService/GetProcessResultForCorrelationTests.cs
+++ b/dotnet/tests/ConsumerAPIService/GetProcessResultForCorrelationTests.cs
@@ -28,22 +28,20 @@ namespace ProcessEngine.ConsumerAPI.Client.Tests
         [Fact]
         public async Task BPMN_GetProcessResultForCorrelation_ShouldGetResultOfStaticProcess()
         {
-            string processModelId = "test_consumer_api_correlation_result";
-            string endEventId = "EndEvent_Success";
-            var identity = DummyIdentity.Create();
+            var processModelId = "test_consumer_api_correlation_result";
+            var endEventId = "EndEvent_Success";
+            var payload = new ProcessStartRequestPayload<object>();
+            var callbackType = StartCallbackType.CallbackOnEndEventReached;
 
-            ProcessStartResponsePayload processInstance = await this.fixture.ConsumerAPIClient.StartProcessInstance(
-                identity,
-                processModelId,
-                "StartEvent_1",
-                new ProcessStartRequestPayload<object>(),
-                StartCallbackType.CallbackOnEndEventReached,
-                endEventId);
+            ProcessStartResponsePayload processInstance = await this
+                .fixture
+                .ConsumerAPIClient
+                .StartProcessInstance(this.fixture.DefaultIdentity, processModelId, "StartEvent_1", payload, callbackType, endEventId);
 
-            var correlationResults = await this.fixture.ConsumerAPIClient.GetProcessResultForCorrelation<TestResult>(
-                identity,
-                processInstance.CorrelationId,
-                processModelId);
+            var correlationResults = await this
+                .fixture
+                .ConsumerAPIClient
+                .GetProcessResultForCorrelation<TestResult>(this.fixture.DefaultIdentity, processInstance.CorrelationId, processModelId);
 
             var expectedCorrelationResult = new CorrelationResult<TestResult>
             {

--- a/dotnet/tests/ConsumerAPIService/GetWaitingManualTasksByIdentityTests.cs
+++ b/dotnet/tests/ConsumerAPIService/GetWaitingManualTasksByIdentityTests.cs
@@ -1,0 +1,50 @@
+namespace ProcessEngine.ConsumerAPI.Client.Tests
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System;
+    using System.Threading;
+
+    using EssentialProjects.IAM.Contracts;
+
+    using ProcessEngine.ConsumerAPI.Client.Tests.xUnit;
+    using ProcessEngine.ConsumerAPI.Contracts.DataModel;
+    using ProcessEngine.ConsumerAPI.Contracts;
+
+    using Xunit;
+
+    [Collection("ConsumerAPI collection")]
+    public class GetWaitingManualTasksByIdentityTests : ProcessEngineBaseTest
+    {
+        private readonly ConsumerAPIFixture fixture;
+
+        public GetWaitingManualTasksByIdentityTests(ConsumerAPIFixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact]
+        public async Task BPMN_GetWaitingManualTasksByIdentity_ShouldFetchManualTaskList()
+        {
+            string processModelId = "test_consumer_api_manualtask";
+            var identity = DummyIdentity.Create();
+
+            ProcessStartResponsePayload processInstance = await this.fixture.ConsumerAPIClient.StartProcessInstance(
+                identity,
+                processModelId,
+                "StartEvent_1",
+                new ProcessStartRequestPayload<object>(),
+                StartCallbackType.CallbackOnProcessInstanceCreated);
+
+            // Give the process engine time to reach the user task
+            await Task.Delay(1000);
+
+            ManualTaskList manualTasks = await this.fixture.ConsumerAPIClient.GetWaitingManualTasksByIdentity(identity);
+
+            Assert.NotEmpty(manualTasks.ManualTasks);
+        }
+
+    }
+}

--- a/dotnet/tests/ConsumerAPIService/GetWaitingManualTasksByIdentityTests.cs
+++ b/dotnet/tests/ConsumerAPIService/GetWaitingManualTasksByIdentityTests.cs
@@ -28,20 +28,19 @@ namespace ProcessEngine.ConsumerAPI.Client.Tests
         [Fact]
         public async Task BPMN_GetWaitingManualTasksByIdentity_ShouldFetchManualTaskList()
         {
-            string processModelId = "test_consumer_api_manualtask";
-            var identity = DummyIdentity.Create();
+            var processModelId = "test_consumer_api_manualtask";
+            var payload = new ProcessStartRequestPayload<object>();
+            var callbackType = StartCallbackType.CallbackOnProcessInstanceCreated;
 
-            ProcessStartResponsePayload processInstance = await this.fixture.ConsumerAPIClient.StartProcessInstance(
-                identity,
-                processModelId,
-                "StartEvent_1",
-                new ProcessStartRequestPayload<object>(),
-                StartCallbackType.CallbackOnProcessInstanceCreated);
+            ProcessStartResponsePayload processInstance = await this
+                .fixture
+                .ConsumerAPIClient
+                .StartProcessInstance(this.fixture.DefaultIdentity, processModelId, "StartEvent_1", payload, callbackType);
 
             // Give the process engine time to reach the user task
-            await Task.Delay(1000);
+            await Task.Delay(2000);
 
-            ManualTaskList manualTasks = await this.fixture.ConsumerAPIClient.GetWaitingManualTasksByIdentity(identity);
+            ManualTaskList manualTasks = await this.fixture.ConsumerAPIClient.GetWaitingManualTasksByIdentity(this.fixture.DefaultIdentity);
 
             Assert.NotEmpty(manualTasks.ManualTasks);
         }

--- a/dotnet/tests/ConsumerAPIService/ProcessEngineBaseTest.cs
+++ b/dotnet/tests/ConsumerAPIService/ProcessEngineBaseTest.cs
@@ -24,8 +24,8 @@ namespace ProcessEngine.ConsumerAPI.Client.Tests
 
         private void SetProcessEngineRestApiUrl()
         {
-            string baseUrlFromEnv = Environment.GetEnvironmentVariable("PROCESS_ENGINE_REST_API_URL");
-            string baseUrl = string.IsNullOrEmpty(baseUrlFromEnv) ? "http://localhost:8080" : baseUrlFromEnv;
+            var baseUrlFromEnv = Environment.GetEnvironmentVariable("PROCESS_ENGINE_REST_API_URL");
+            var baseUrl = string.IsNullOrEmpty(baseUrlFromEnv) ? "http://localhost:8080" : baseUrlFromEnv;
 
             this.processEngineRestApiUrl = $"{baseUrl}";
         }

--- a/dotnet/tests/ConsumerAPIService/StartProcessInstanceTests.cs
+++ b/dotnet/tests/ConsumerAPIService/StartProcessInstanceTests.cs
@@ -27,53 +27,52 @@ namespace ProcessEngine.ConsumerAPI.Client.Tests
         [Fact]
         public void StartProcessInstance_EmptyParameters_ShouldThrowException()
         {
-            var ex = Assert.ThrowsAsync<ArgumentNullException>(async () => await this.fixture.ConsumerAPIClient.StartProcessInstance(
-                DummyIdentity.Create(),
-                "",
-                "Test",
-                new ProcessStartRequestPayload<object>()));
+            var payload = new ProcessStartRequestPayload<object>();
+
+            var ex = Assert.ThrowsAsync<ArgumentNullException>(async () => await this
+                .fixture
+                .ConsumerAPIClient
+                .StartProcessInstance(this.fixture.DefaultIdentity, "", "Test", payload));
         }
 
         [Fact]
         public void StartProcessInstance_ProcessModelNotFound_ShouldThrowException()
         {
-            var ex = Assert.ThrowsAsync<Exception>(async () => await this.fixture.ConsumerAPIClient.StartProcessInstance(
-                DummyIdentity.Create(),
-                "Test",
-                "Test",
-                new ProcessStartRequestPayload<object>()));
+            var payload = new ProcessStartRequestPayload<object>();
+
+            var ex = Assert.ThrowsAsync<Exception>(async () => await this
+                .fixture
+                .ConsumerAPIClient
+                .StartProcessInstance(this.fixture.DefaultIdentity, "Test", "Test", payload));
         }
 
         [Fact]
         public async Task BPMN_StartProcessInstance_ShouldCreateAndFinishProcess()
         {
-            string processModelId = "test_start_process";
+            var processModelId = "test_start_process";
+            var payload = new ProcessStartRequestPayload<object>();
+            var callbackType = StartCallbackType.CallbackOnEndEventReached;
 
-            ProcessStartResponsePayload processInstance = await this.fixture.ConsumerAPIClient.StartProcessInstance(
-                DummyIdentity.Create(),
-                processModelId,
-                "StartEvent_1",
-                new ProcessStartRequestPayload<object>(),
-                StartCallbackType.CallbackOnEndEventReached,
-                "EndEvent_1");
+            ProcessStartResponsePayload processInstance = await this
+                .fixture
+                .ConsumerAPIClient
+                .StartProcessInstance(this.fixture.DefaultIdentity, processModelId, "StartEvent_1", payload, callbackType, "EndEvent_1");
         }
 
         [Fact]
         public async Task BPMN_StartProcessInstance_ShouldCreateProcessWithDistinctCorrelationId()
         {
-            string processModelId = "test_start_process";
-            string correlationId = "CorrelationId_1";
-
-            var requestPayload = new ProcessStartRequestPayload<object>
+            var processModelId = "test_start_process";
+            var correlationId = "CorrelationId_1";
+            var payload = new ProcessStartRequestPayload<object>
             {
                 CorrelationId = correlationId
             };
 
-            ProcessStartResponsePayload processStartResponsePayload = await this.fixture.ConsumerAPIClient.StartProcessInstance(
-                DummyIdentity.Create(),
-                processModelId,
-                "StartEvent_1",
-                requestPayload);
+            ProcessStartResponsePayload processStartResponsePayload = await this
+                .fixture
+                .ConsumerAPIClient
+                .StartProcessInstance(this.fixture.DefaultIdentity, processModelId, "StartEvent_1", payload);
 
             Assert.Equal(processStartResponsePayload.CorrelationId, correlationId);
         }
@@ -81,15 +80,13 @@ namespace ProcessEngine.ConsumerAPI.Client.Tests
         [Fact]
         public async Task BPMN_StartProcessInstance_ShouldCreateCorrelationIdIfNoneProvided()
         {
-            string processModelId = "test_start_process";
+            var processModelId = "test_start_process";
+            var payload = new ProcessStartRequestPayload<object>();
 
-            var requestPayload = new ProcessStartRequestPayload<object>();
-
-            ProcessStartResponsePayload processStartResponsePayload = await this.fixture.ConsumerAPIClient.StartProcessInstance(
-                DummyIdentity.Create(),
-                processModelId,
-                "StartEvent_1",
-                requestPayload);
+            ProcessStartResponsePayload processStartResponsePayload = await this
+                .fixture
+                .ConsumerAPIClient
+                .StartProcessInstance(this.fixture.DefaultIdentity, processModelId, "StartEvent_1", payload);
 
             Assert.NotEmpty(processStartResponsePayload.CorrelationId);
         }

--- a/dotnet/tests/ConsumerAPIService/TriggerMessageEventTests.cs
+++ b/dotnet/tests/ConsumerAPIService/TriggerMessageEventTests.cs
@@ -33,25 +33,21 @@ namespace ProcessEngine.ConsumerAPI.Client.Tests
 
             var requestPayload = new ProcessStartRequestPayload<object>();
 
-            ProcessStartResponsePayload processStartResponsePayload = await this.fixture.ConsumerAPIClient.StartProcessInstance(
-                identity,
-                processModelId,
-                "StartEvent_1",
-                requestPayload);
+            ProcessStartResponsePayload processStartResponsePayload = await this
+                .fixture
+                .ConsumerAPIClient
+                .StartProcessInstance(identity, processModelId, "StartEvent_1", requestPayload);
 
             await Task.Delay(5000);
 
-            await this.fixture.ConsumerAPIClient.TriggerMessageEvent(
-                DummyIdentity.Create(),
-                messageName
-            );
+            await this.fixture.ConsumerAPIClient.TriggerMessageEvent(identity,messageName);
 
             await Task.Delay(5000);
 
-            var processResult = await this.fixture.ConsumerAPIClient.GetProcessResultForCorrelation<object>(
-                identity,
-                processStartResponsePayload.CorrelationId,
-                processModelId);
+            var processResult = await this
+                .fixture
+                .ConsumerAPIClient
+                .GetProcessResultForCorrelation<object>(identity, processStartResponsePayload.CorrelationId, processModelId);
 
             Assert.NotEmpty(processResult);
         }

--- a/dotnet/tests/ConsumerAPIService/TriggerMessageEventTests.cs
+++ b/dotnet/tests/ConsumerAPIService/TriggerMessageEventTests.cs
@@ -27,7 +27,6 @@ namespace ProcessEngine.ConsumerAPI.Client.Tests
         [Fact]
         public async Task BPMN_TriggerMessageEvent_ShouldContinueProcessWithMessageIntermediateCatchEvent()
         {
-            var identity = DummyIdentity.Create();
             string processModelId = "test_consumer_api_message_event";
             string messageName = "test_message_event";
 
@@ -36,18 +35,18 @@ namespace ProcessEngine.ConsumerAPI.Client.Tests
             ProcessStartResponsePayload processStartResponsePayload = await this
                 .fixture
                 .ConsumerAPIClient
-                .StartProcessInstance(identity, processModelId, "StartEvent_1", requestPayload);
+                .StartProcessInstance(this.fixture.DefaultIdentity, processModelId, "StartEvent_1", requestPayload);
 
             await Task.Delay(5000);
 
-            await this.fixture.ConsumerAPIClient.TriggerMessageEvent(identity,messageName);
+            await this.fixture.ConsumerAPIClient.TriggerMessageEvent(this.fixture.DefaultIdentity, messageName);
 
             await Task.Delay(5000);
 
             var processResult = await this
                 .fixture
                 .ConsumerAPIClient
-                .GetProcessResultForCorrelation<object>(identity, processStartResponsePayload.CorrelationId, processModelId);
+                .GetProcessResultForCorrelation<object>(this.fixture.DefaultIdentity, processStartResponsePayload.CorrelationId, processModelId);
 
             Assert.NotEmpty(processResult);
         }

--- a/dotnet/tests/ConsumerAPIService/TriggerMessageEventTests.cs
+++ b/dotnet/tests/ConsumerAPIService/TriggerMessageEventTests.cs
@@ -39,7 +39,7 @@ namespace ProcessEngine.ConsumerAPI.Client.Tests
                 "StartEvent_1",
                 requestPayload);
 
-            await Task.Delay(1000);
+            await Task.Delay(5000);
 
             await this.fixture.ConsumerAPIClient.TriggerMessageEvent(
                 DummyIdentity.Create(),

--- a/dotnet/tests/ConsumerAPIService/TriggerSignalEventTests.cs
+++ b/dotnet/tests/ConsumerAPIService/TriggerSignalEventTests.cs
@@ -33,25 +33,21 @@ namespace ProcessEngine.ConsumerAPI.Client.Tests
 
             var requestPayload = new ProcessStartRequestPayload<object>();
 
-            ProcessStartResponsePayload processStartResponsePayload = await this.fixture.ConsumerAPIClient.StartProcessInstance(
-                identity,
-                processModelId,
-                "StartEvent_1",
-                requestPayload);
-
-            await Task.Delay(1000);
-
-            await this.fixture.ConsumerAPIClient.TriggerSignalEvent(
-                DummyIdentity.Create(),
-                signalName
-            );
+            ProcessStartResponsePayload processStartResponsePayload = await this
+                .fixture
+                .ConsumerAPIClient
+                .StartProcessInstance(identity, processModelId, "StartEvent_1", requestPayload);
 
             await Task.Delay(5000);
 
-            var processResult = await this.fixture.ConsumerAPIClient.GetProcessResultForCorrelation<object>(
-                identity,
-                processStartResponsePayload.CorrelationId,
-                processModelId);
+            await this.fixture.ConsumerAPIClient.TriggerSignalEvent(identity,signalName);
+
+            await Task.Delay(5000);
+
+            var processResult = await this
+                .fixture
+                .ConsumerAPIClient
+                .GetProcessResultForCorrelation<object>(identity, processStartResponsePayload.CorrelationId, processModelId);
 
             Assert.NotEmpty(processResult);
         }

--- a/dotnet/tests/ConsumerAPIService/TriggerSignalEventTests.cs
+++ b/dotnet/tests/ConsumerAPIService/TriggerSignalEventTests.cs
@@ -27,7 +27,6 @@ namespace ProcessEngine.ConsumerAPI.Client.Tests
         [Fact]
         public async Task BPMN_TriggerSignalEvent_ShouldContinueProcessWithSignalIntermediateCatchEvent()
         {
-            var identity = DummyIdentity.Create();
             string processModelId = "test_consumer_api_signal_event";
             string signalName = "test_signal_event";
 
@@ -36,18 +35,18 @@ namespace ProcessEngine.ConsumerAPI.Client.Tests
             ProcessStartResponsePayload processStartResponsePayload = await this
                 .fixture
                 .ConsumerAPIClient
-                .StartProcessInstance(identity, processModelId, "StartEvent_1", requestPayload);
+                .StartProcessInstance(this.fixture.DefaultIdentity, processModelId, "StartEvent_1", requestPayload);
 
             await Task.Delay(5000);
 
-            await this.fixture.ConsumerAPIClient.TriggerSignalEvent(identity,signalName);
+            await this.fixture.ConsumerAPIClient.TriggerSignalEvent(this.fixture.DefaultIdentity, signalName);
 
             await Task.Delay(5000);
 
             var processResult = await this
                 .fixture
                 .ConsumerAPIClient
-                .GetProcessResultForCorrelation<object>(identity, processStartResponsePayload.CorrelationId, processModelId);
+                .GetProcessResultForCorrelation<object>(this.fixture.DefaultIdentity, processStartResponsePayload.CorrelationId, processModelId);
 
             Assert.NotEmpty(processResult);
         }

--- a/dotnet/tests/ProcessEngine.ConsumerAPI.Client.Tests.csproj
+++ b/dotnet/tests/ProcessEngine.ConsumerAPI.Client.Tests.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="9.0.0-feature-enhance-user-task-api" />
+    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="9.1.0-feature-add-manual-task-consumer-api" />
     <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
@@ -25,6 +25,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="bpmn\test_consumer_api_message_event.bpmn">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="bpmn\test_consumer_api_manualtask.bpmn">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/dotnet/tests/ProcessEngine.ConsumerAPI.Client.Tests.csproj
+++ b/dotnet/tests/ProcessEngine.ConsumerAPI.Client.Tests.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="9.1.0-feature-add-manual-task-consumer-api" />
+    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="10.0.0-feature-add-manual-task-consumer-api" />
     <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="xunit" Version="2.4.0" />

--- a/dotnet/tests/bpmn/test_consumer_api_manualtask.bpmn
+++ b/dotnet/tests/bpmn/test_consumer_api_manualtask.bpmn
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definition_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="BPMN Studio" exporterVersion="1">
+  <bpmn:collaboration id="Collaboration_1cidyxu" name="">
+    <bpmn:participant id="Participant_0px403d" name="test_consumer_api_manualtask" processRef="test_consumer_api_manualtask" />
+  </bpmn:collaboration>
+  <bpmn:process id="test_consumer_api_manualtask" name="test_consumer_api_manualtask" isExecutable="true">
+    <bpmn:laneSet>
+      <bpmn:lane id="Lane_1xzf0d3" name="Default_Test_Lane">
+        <bpmn:flowNodeRef>StartEvent_1</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>EndEvent_1</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_0gmd1s3</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+    <bpmn:startEvent id="StartEvent_1" name="Start Event">
+      <bpmn:outgoing>SequenceFlow_1fotkzw</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_1" name="End Event">
+      <bpmn:incoming>SequenceFlow_1889f4o</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1fotkzw" sourceRef="StartEvent_1" targetRef="Task_0gmd1s3" />
+    <bpmn:manualTask id="Task_0gmd1s3" name="Manual Task">
+      <bpmn:incoming>SequenceFlow_1fotkzw</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1889f4o</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:sequenceFlow id="SequenceFlow_1889f4o" sourceRef="Task_0gmd1s3" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1cidyxu">
+      <bpmndi:BPMNShape id="Participant_0px403d_di" bpmnElement="Participant_0px403d">
+        <dc:Bounds x="5" y="4" width="581" height="170" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_1xzf0d3_di" bpmnElement="Lane_1xzf0d3">
+        <dc:Bounds x="35" y="4" width="551" height="170" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_1mox3jl_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="83" y="69" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="74" y="105" width="55" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0eie6q6_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="503" y="69" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="496" y="105" width="51" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1fotkzw_di" bpmnElement="SequenceFlow_1fotkzw">
+        <di:waypoint x="119" y="87" />
+        <di:waypoint x="169" y="87" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ManualTask_0nxpkd7_di" bpmnElement="Task_0gmd1s3">
+        <dc:Bounds x="169" y="47" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1889f4o_di" bpmnElement="SequenceFlow_1889f4o">
+        <di:waypoint x="269" y="87" />
+        <di:waypoint x="503" y="87" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/dotnet/tests/xUnit/ConsumerAPIFixture.cs
+++ b/dotnet/tests/xUnit/ConsumerAPIFixture.cs
@@ -14,16 +14,17 @@ namespace ProcessEngine.ConsumerAPI.Client.Tests.xUnit {
     using Newtonsoft.Json;
 
     public class ConsumerAPIFixture {
-        public ConsumerApiClientService ConsumerAPIClient { get; private set; }
 
         private HttpClient httpClient;
 
         private string processEngineRestApiUrl;
 
         public ConsumerAPIFixture () {
-            SetProcessEngineRestApiUrl ();
+            SetProcessEngineRestApiUrl();
 
-            CreateConsumerAPIClient ();
+            CreateConsumerAPIClient();
+
+            this.DefaultIdentity = DummyIdentity.Create();
 
             // Deploy test files from ./bpmn folder. The property "Copy to output directory" has to be true for these files.
             foreach (var file in Directory.GetFiles ("./bpmn")) {
@@ -35,6 +36,9 @@ namespace ProcessEngine.ConsumerAPI.Client.Tests.xUnit {
                 }
             }
         }
+        public ConsumerApiClientService ConsumerAPIClient { get; private set; }
+
+        public IIdentity DefaultIdentity { get; private set; }
 
         private void SetProcessEngineRestApiUrl () {
             string baseUrlFromEnv = Environment.GetEnvironmentVariable ("PROCESS_ENGINE_REST_API_URL");

--- a/dotnet/tests/xUnit/DummyIdentity.cs
+++ b/dotnet/tests/xUnit/DummyIdentity.cs
@@ -1,4 +1,4 @@
-namespace ProcessEngine.ConsumerAPI.Client
+namespace ProcessEngine.ConsumerAPI.Client.Tests.xUnit
 {
     using System;
     using System.Text;


### PR DESCRIPTION
**Changes:**

1. Fixed redundant slash in url construction
2. Added implementation for methods of the ManualTaskConsumer API
3. Added tests for the implemented methods
4. Set alias for `RestSettings` to make code more understandable

PR: #43 

## How can others test the changes?

Run the tests.

_Note:_
Currently the docker image of `process_engine_runtime` has a known issue (https://github.com/process-engine/process_engine_runtime_docker_image/issues/7).
The automated tests run by Jenkins will succeed as soon as the issue has been resolved (next release).
In the meantime you can start the `process_engine_runtime` locally (without using the docker image) to run the tests.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).