### PR TITLE
✨Additional notifications for activities

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -31,7 +31,7 @@
     "@essential-projects/errors_ts": "^1.5.0",
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/consumer_api_contracts": "feature~additional_notifications_for_activities",
+    "@process-engine/consumer_api_contracts": "7.0.0-8393af71-b15",
     "async-middleware": "^1.2.1",
     "bluebird": "^3.5.3",
     "loggerhythm": "^3.0.3",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -31,7 +31,7 @@
     "@essential-projects/errors_ts": "^1.5.0",
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/consumer_api_contracts": "7.0.0-f7e1f918-b14",
+    "@process-engine/consumer_api_contracts": "feature~additional_notifications_for_activities",
     "async-middleware": "^1.2.1",
     "bluebird": "^3.5.3",
     "loggerhythm": "^3.0.3",

--- a/typescript/src/accessors/external_accessor.ts
+++ b/typescript/src/accessors/external_accessor.ts
@@ -70,6 +70,26 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     return this.createSocketIoSubscription(identity, socketSettings.paths.activityFinished, callback, subscribeOnce);
   }
 
+  // ------------ For backwards compatibility only
+
+  public async onCallActivityWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnCallActivityWaitingCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.createSocketIoSubscription(identity, socketSettings.paths.activityReached, callback, subscribeOnce);
+  }
+
+  public async onCallActivityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnCallActivityFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.createSocketIoSubscription(identity, socketSettings.paths.activityFinished, callback, subscribeOnce);
+  }
+
+  // ------------
+
   public async onEmptyActivityWaiting(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnEmptyActivityWaitingCallback,

--- a/typescript/src/accessors/external_accessor.ts
+++ b/typescript/src/accessors/external_accessor.ts
@@ -77,7 +77,7 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     callback: Messages.CallbackTypes.OnCallActivityWaitingCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    return this.createSocketIoSubscription(identity, socketSettings.paths.activityReached, callback, subscribeOnce);
+    return this.createSocketIoSubscription(identity, socketSettings.paths.callActivityWaiting, callback, subscribeOnce);
   }
 
   public async onCallActivityFinished(
@@ -85,7 +85,7 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     callback: Messages.CallbackTypes.OnCallActivityFinishedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    return this.createSocketIoSubscription(identity, socketSettings.paths.activityFinished, callback, subscribeOnce);
+    return this.createSocketIoSubscription(identity, socketSettings.paths.callActivityFinished, callback, subscribeOnce);
   }
 
   // ------------

--- a/typescript/src/accessors/external_accessor.ts
+++ b/typescript/src/accessors/external_accessor.ts
@@ -53,6 +53,23 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
   }
 
   // Notifications
+
+  public async onActivityReached(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnActivityReachedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<any> {
+    return this.createSocketIoSubscription(identity, socketSettings.paths.activityReached, callback, subscribeOnce);
+  }
+
+  public async onActivityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnActivityFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<any> {
+    return this.createSocketIoSubscription(identity, socketSettings.paths.activityFinished, callback, subscribeOnce);
+  }
+
   public async onEmptyActivityWaiting(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnEmptyActivityWaitingCallback,
@@ -137,22 +154,6 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     subscribeOnce: boolean = false,
   ): Promise<any> {
     return this.createSocketIoSubscription(identity, socketSettings.paths.intermediateCatchEventFinished, callback, subscribeOnce);
-  }
-
-  public async onCallActivityWaiting(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnCallActivityWaitingCallback,
-    subscribeOnce: boolean = false,
-  ): Promise<any> {
-    return this.createSocketIoSubscription(identity, socketSettings.paths.callActivityWaiting, callback, subscribeOnce);
-  }
-
-  public async onCallActivityFinished(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnCallActivityFinishedCallback,
-    subscribeOnce: boolean = false,
-  ): Promise<any> {
-    return this.createSocketIoSubscription(identity, socketSettings.paths.callActivityFinished, callback, subscribeOnce);
   }
 
   public async onUserTaskForIdentityWaiting(

--- a/typescript/src/accessors/internal_accessor.ts
+++ b/typescript/src/accessors/internal_accessor.ts
@@ -33,6 +33,26 @@ export class InternalAccessor implements IConsumerApiAccessor {
     return this.consumerApiService.onActivityFinished(identity, callback, subscribeOnce);
   }
 
+  // ------------ For backwards compatibility only
+
+  public async onCallActivityWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnCallActivityWaitingCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.consumerApiService.onCallActivityWaiting(identity, callback, subscribeOnce);
+  }
+
+  public async onCallActivityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnCallActivityFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.consumerApiService.onCallActivityFinished(identity, callback, subscribeOnce);
+  }
+
+  // ------------
+
   public async onEmptyActivityWaiting(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnEmptyActivityWaitingCallback,

--- a/typescript/src/accessors/internal_accessor.ts
+++ b/typescript/src/accessors/internal_accessor.ts
@@ -17,6 +17,22 @@ export class InternalAccessor implements IConsumerApiAccessor {
   }
 
   // Notifications
+  public async onActivityReached(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnActivityReachedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.consumerApiService.onActivityReached(identity, callback, subscribeOnce);
+  }
+
+  public async onActivityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnActivityFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.consumerApiService.onActivityFinished(identity, callback, subscribeOnce);
+  }
+
   public async onEmptyActivityWaiting(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnEmptyActivityWaitingCallback,
@@ -111,22 +127,6 @@ export class InternalAccessor implements IConsumerApiAccessor {
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
     return this.consumerApiService.onIntermediateCatchEventFinished(identity, callback, subscribeOnce);
-  }
-
-  public async onCallActivityWaiting(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnCallActivityWaitingCallback,
-    subscribeOnce: boolean = false,
-  ): Promise<Subscription> {
-    return this.consumerApiService.onCallActivityWaiting(identity, callback, subscribeOnce);
-  }
-
-  public async onCallActivityFinished(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnCallActivityFinishedCallback,
-    subscribeOnce: boolean = false,
-  ): Promise<Subscription> {
-    return this.consumerApiService.onCallActivityFinished(identity, callback, subscribeOnce);
   }
 
   public async onManualTaskWaiting(

--- a/typescript/src/consumer_api_client_service.ts
+++ b/typescript/src/consumer_api_client_service.ts
@@ -1,3 +1,5 @@
+import {Logger} from 'loggerhythm';
+
 import * as EssentialProjectErrors from '@essential-projects/errors_ts';
 import {Subscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
@@ -8,6 +10,8 @@ import {
   IConsumerApiAccessor,
   Messages,
 } from '@process-engine/consumer_api_contracts';
+
+const logger = Logger.createLogger('processengine:consumer_api:client');
 
 export class ConsumerApiClientService implements IConsumerApi {
 
@@ -37,6 +41,34 @@ export class ConsumerApiClientService implements IConsumerApi {
 
     return this.consumerApiAccessor.onActivityFinished(identity, callback, subscribeOnce);
   }
+
+  // ------------ For backwards compatibility only
+
+  public async onCallActivityWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnCallActivityWaitingCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    this.ensureIsAuthorized(identity);
+
+    logger.warn('"onCallActivityWaiting" is deprecated and will be removed with the next major release! Use "onActivityReached" instead!');
+
+    return this.consumerApiAccessor.onCallActivityWaiting(identity, callback, subscribeOnce);
+  }
+
+  public async onCallActivityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnCallActivityFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    this.ensureIsAuthorized(identity);
+
+    logger.warn('"onCallActivityFinished" is deprecated and will be removed with the next major release! Use "onActivityFinished" instead!');
+
+    return this.consumerApiAccessor.onCallActivityFinished(identity, callback, subscribeOnce);
+  }
+
+  // ------------
 
   public async onEmptyActivityWaiting(
     identity: IIdentity,

--- a/typescript/src/consumer_api_client_service.ts
+++ b/typescript/src/consumer_api_client_service.ts
@@ -18,6 +18,26 @@ export class ConsumerApiClientService implements IConsumerApi {
   }
 
   // Notifications
+  public async onActivityReached(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnActivityReachedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    this.ensureIsAuthorized(identity);
+
+    return this.consumerApiAccessor.onActivityReached(identity, callback, subscribeOnce);
+  }
+
+  public async onActivityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnActivityFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    this.ensureIsAuthorized(identity);
+
+    return this.consumerApiAccessor.onActivityFinished(identity, callback, subscribeOnce);
+  }
+
   public async onEmptyActivityWaiting(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnEmptyActivityWaitingCallback,
@@ -136,26 +156,6 @@ export class ConsumerApiClientService implements IConsumerApi {
     this.ensureIsAuthorized(identity);
 
     return this.consumerApiAccessor.onIntermediateCatchEventFinished(identity, callback, subscribeOnce);
-  }
-
-  public async onCallActivityWaiting(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnCallActivityWaitingCallback,
-    subscribeOnce: boolean = false,
-  ): Promise<Subscription> {
-    this.ensureIsAuthorized(identity);
-
-    return this.consumerApiAccessor.onCallActivityWaiting(identity, callback, subscribeOnce);
-  }
-
-  public async onCallActivityFinished(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnCallActivityFinishedCallback,
-    subscribeOnce: boolean = false,
-  ): Promise<Subscription> {
-    this.ensureIsAuthorized(identity);
-
-    return this.consumerApiAccessor.onCallActivityFinished(identity, callback, subscribeOnce);
   }
 
   public async onProcessTerminated(


### PR DESCRIPTION
## Changes

1. Refactor notification subscriptions `onCallActivityWaiting` to `onActivityReached` and `onCallActivityFinished` to `onActivityFinished`.
2. Generalize activity subscription paths, messages and types.
    - This will allow the user to susbcribe to notifications about more than just CallActivities, but also ScriptTasks, SendTasks, ReceiveTasks, ServiceTasks and Subprocesses.
3. Mark `onCallActivityWaiting` and `onCallActivityFinished` as deprecated.
    - The notifications will be removed with the next major release, to give people time to properly adjust their usage of the notifications.

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/349

PR: #49

## How to test the changes

- Create Subscriptions for `onActivityReached` and `onActivityFinished`
- The corresponding callbacks will be triggered, when any kind of activity is reached or finished

