### PR TITLE
✨ Implement .NET EmptyActivityApi

### DIFF
--- a/dotnet/src/ConsumerApiClientService.cs
+++ b/dotnet/src/ConsumerApiClientService.cs
@@ -117,9 +117,7 @@
             var endpoint = RestSettings.Paths.ProcessModelEvents
                 .Replace(RestSettings.Params.ProcessModelId, processModelId);
 
-            var urlWithEndpoint = this.ApplyBaseUrl(endpoint);
-
-            var parsedResult = await this.GetTriggerableEventsFromUrl(identity, urlWithEndpoint);
+            var parsedResult = await this.GetTriggerableEventsFromUrl(identity, endpoint);
 
             return parsedResult;
         }
@@ -129,9 +127,7 @@
             var endpoint = RestSettings.Paths.CorrelationEvents
                 .Replace(RestSettings.Params.CorrelationId, correlationId);
 
-            var urlWithEndpoint = this.ApplyBaseUrl(endpoint);
-
-            var parsedResult = await this.GetTriggerableEventsFromUrl(identity, urlWithEndpoint);
+            var parsedResult = await this.GetTriggerableEventsFromUrl(identity, endpoint);
 
             return parsedResult;
         }
@@ -142,9 +138,7 @@
                 .Replace(RestSettings.Params.ProcessModelId, processModelId)
                 .Replace(RestSettings.Params.CorrelationId, correlationId);
 
-            var urlWithEndpoint = this.ApplyBaseUrl(endpoint);
-
-            var parsedResult = await this.GetTriggerableEventsFromUrl(identity, urlWithEndpoint);
+            var parsedResult = await this.GetTriggerableEventsFromUrl(identity, endpoint);
 
             return parsedResult;
         }
@@ -200,9 +194,7 @@
             var endpoint = RestSettings.Paths.ProcessInstanceEmptyActivities
                 .Replace(RestSettings.Params.ProcessModelId, processModelId);
 
-            var urlWithEndpoint = this.ApplyBaseUrl(endpoint);
-
-            var parsedResult = await this.GetEmptyActivitiesFromUrl(identity, urlWithEndpoint);
+            var parsedResult = await this.GetEmptyActivitiesFromUrl(identity, endpoint);
 
             return parsedResult;
         }
@@ -212,9 +204,7 @@
             var endpoint = RestSettings.Paths.ProcessInstanceEmptyActivities
                 .Replace(RestSettings.Params.ProcessInstanceId, processInstanceId);
 
-            var urlWithEndpoint = this.ApplyBaseUrl(endpoint);
-
-            var parsedResult = await this.GetEmptyActivitiesFromUrl(identity, urlWithEndpoint);
+            var parsedResult = await this.GetEmptyActivitiesFromUrl(identity, endpoint);
 
             return parsedResult;
         }
@@ -224,9 +214,7 @@
             var endpoint = RestSettings.Paths.CorrelationEmptyActivities
                 .Replace(RestSettings.Params.CorrelationId, correlationId);
 
-            var urlWithEndpoint = this.ApplyBaseUrl(endpoint);
-
-            var parsedResult = await this.GetEmptyActivitiesFromUrl(identity, urlWithEndpoint);
+            var parsedResult = await this.GetEmptyActivitiesFromUrl(identity, endpoint);
 
             return parsedResult;
         }
@@ -237,9 +225,7 @@
                 .Replace(RestSettings.Params.ProcessModelId, processModelId)
                 .Replace(RestSettings.Params.CorrelationId, correlationId);
 
-            var urlWithEndpoint = this.ApplyBaseUrl(endpoint);
-
-            var parsedResult = await this.GetEmptyActivitiesFromUrl(identity, urlWithEndpoint);
+            var parsedResult = await this.GetEmptyActivitiesFromUrl(identity, endpoint);
 
             return parsedResult;
         }
@@ -248,9 +234,7 @@
         {
             var endpoint = RestSettings.Paths.GetOwnEmptyActivities;
 
-            var urlWithEndpoint = this.ApplyBaseUrl(endpoint);
-
-            var parsedResult = await this.GetEmptyActivitiesFromUrl(identity, urlWithEndpoint);
+            var parsedResult = await this.GetEmptyActivitiesFromUrl(identity, endpoint);
 
             return parsedResult;
         }
@@ -278,9 +262,7 @@
             var endpoint = RestSettings.Paths.ProcessModelUserTasks
                 .Replace(RestSettings.Params.ProcessModelId, processModelId);
 
-            var urlWithEndpoint = this.ApplyBaseUrl(endpoint);
-
-            var parsedResult = await this.GetUserTasksFromUrl(identity, urlWithEndpoint);
+            var parsedResult = await this.GetUserTasksFromUrl(identity, endpoint);
 
             return parsedResult;
         }
@@ -290,9 +272,7 @@
             var endpoint = RestSettings.Paths.ProcessInstanceUserTasks
                 .Replace(RestSettings.Params.ProcessInstanceId, processInstanceId);
 
-            var urlWithEndpoint = this.ApplyBaseUrl(endpoint);
-
-            var parsedResult = await this.GetUserTasksFromUrl(identity, urlWithEndpoint);
+            var parsedResult = await this.GetUserTasksFromUrl(identity, endpoint);
 
             return parsedResult;
         }
@@ -302,9 +282,7 @@
             var endpoint = RestSettings.Paths.CorrelationUserTasks
                 .Replace(RestSettings.Params.CorrelationId, correlationId);
 
-            var urlWithEndpoint = this.ApplyBaseUrl(endpoint);
-
-            var parsedResult = await this.GetUserTasksFromUrl(identity, urlWithEndpoint);
+            var parsedResult = await this.GetUserTasksFromUrl(identity, endpoint);
 
             return parsedResult;
         }
@@ -315,9 +293,7 @@
                 .Replace(RestSettings.Params.ProcessModelId, processModelId)
                 .Replace(RestSettings.Params.CorrelationId, correlationId);
 
-            var urlWithEndpoint = this.ApplyBaseUrl(endpoint);
-
-            var parsedResult = await this.GetUserTasksFromUrl(identity, urlWithEndpoint);
+            var parsedResult = await this.GetUserTasksFromUrl(identity, endpoint);
 
             return parsedResult;
         }
@@ -326,9 +302,7 @@
         {
             var endpoint = RestSettings.Paths.GetOwnUserTasks;
 
-            var urlWithEndpoint = this.ApplyBaseUrl(endpoint);
-
-            var parsedResult = await this.GetUserTasksFromUrl(identity, urlWithEndpoint);
+            var parsedResult = await this.GetUserTasksFromUrl(identity, endpoint);
 
             return parsedResult;
         }
@@ -358,9 +332,7 @@
             var endpoint = RestSettings.Paths.ProcessModelManualTasks
                 .Replace(RestSettings.Params.ProcessModelId, processModelId);
 
-            var urlWithEndpoint = this.ApplyBaseUrl(endpoint);
-
-            var parsedResult = await this.GetManualTasksFromUrl(identity, urlWithEndpoint);
+            var parsedResult = await this.GetManualTasksFromUrl(identity, endpoint);
 
             return parsedResult;
         }
@@ -370,9 +342,7 @@
             var endpoint = RestSettings.Paths.ProcessInstanceManualTasks
                 .Replace(RestSettings.Params.ProcessInstanceId, processInstanceId);
 
-            var urlWithEndpoint = this.ApplyBaseUrl(endpoint);
-
-            var parsedResult = await this.GetManualTasksFromUrl(identity, urlWithEndpoint);
+            var parsedResult = await this.GetManualTasksFromUrl(identity, endpoint);
 
             return parsedResult;
         }
@@ -382,9 +352,7 @@
             var endpoint = RestSettings.Paths.CorrelationManualTasks
                 .Replace(RestSettings.Params.CorrelationId, correlationId);
 
-            var urlWithEndpoint = this.ApplyBaseUrl(endpoint);
-
-            var parsedResult = await this.GetManualTasksFromUrl(identity, urlWithEndpoint);
+            var parsedResult = await this.GetManualTasksFromUrl(identity, endpoint);
 
             return parsedResult;
         }
@@ -395,9 +363,7 @@
                 .Replace(RestSettings.Params.ProcessModelId, processModelId)
                 .Replace(RestSettings.Params.CorrelationId, correlationId);
 
-            var urlWithEndpoint = this.ApplyBaseUrl(endpoint);
-
-            var parsedResult = await this.GetManualTasksFromUrl(identity, urlWithEndpoint);
+            var parsedResult = await this.GetManualTasksFromUrl(identity, endpoint);
 
             return parsedResult;
         }
@@ -406,9 +372,7 @@
         {
             var endpoint = RestSettings.Paths.GetOwnManualTasks;
 
-            var urlWithEndpoint = this.ApplyBaseUrl(endpoint);
-
-            var parsedResult = await this.GetManualTasksFromUrl(identity, urlWithEndpoint);
+            var parsedResult = await this.GetManualTasksFromUrl(identity, endpoint);
 
             return parsedResult;
         }
@@ -464,8 +428,10 @@
             return result;
         }
 
-        private async Task<TResult> SendRequestAndExpectResult<TResult>(IIdentity identity, HttpMethod method, string url, HttpContent content = null)
+        private async Task<TResult> SendRequestAndExpectResult<TResult>(IIdentity identity, HttpMethod method, string endpoint, HttpContent content = null)
         {
+            var url = this.ApplyBaseUrl(endpoint);
+
             TResult parsedResult = default(TResult);
 
             var request = this.CreateRequestMessage(identity, HttpMethod.Get, url);

--- a/dotnet/src/ConsumerApiClientService.cs
+++ b/dotnet/src/ConsumerApiClientService.cs
@@ -196,6 +196,84 @@
             }
         }
 
+        public async Task<EmptyActivityList> GetEmptyActivitiesForProcessModel(IIdentity identity, string processModelId)
+        {
+            var endpoint = RestSettings.Paths.ProcessInstanceEmptyActivities
+                .Replace(RestSettings.Params.ProcessModelId, processModelId);
+
+            var urlWithEndpoint = this.ApplyBaseUrl(endpoint);
+
+            var parsedResult = await this.GetEmptyActivitiesFromUrl(identity, urlWithEndpoint);
+
+            return parsedResult;
+        }
+
+        public async Task<EmptyActivityList> GetEmptyActivitiesForProcessInstance(IIdentity identity, string processInstanceId)
+        {
+            var endpoint = RestSettings.Paths.ProcessInstanceEmptyActivities
+                .Replace(RestSettings.Params.ProcessInstanceId, processInstanceId);
+
+            var urlWithEndpoint = this.ApplyBaseUrl(endpoint);
+
+            var parsedResult = await this.GetEmptyActivitiesFromUrl(identity, urlWithEndpoint);
+
+            return parsedResult;
+        }
+
+        public async Task<EmptyActivityList> GetEmptyActivitiesForCorrelation(IIdentity identity, string correlationId)
+        {
+            var endpoint = RestSettings.Paths.CorrelationEmptyActivities
+                .Replace(RestSettings.Params.CorrelationId, correlationId);
+
+            var urlWithEndpoint = this.ApplyBaseUrl(endpoint);
+
+            var parsedResult = await this.GetEmptyActivitiesFromUrl(identity, urlWithEndpoint);
+
+            return parsedResult;
+        }
+
+        public async Task<EmptyActivityList> GetEmptyActivitiesForProcessModelInCorrelation(IIdentity identity, string processModelId, string correlationId)
+        {
+            var endpoint = RestSettings.Paths.ProcessModelCorrelationEmptyActivities
+                .Replace(RestSettings.Params.ProcessModelId, processModelId)
+                .Replace(RestSettings.Params.CorrelationId, correlationId);
+
+            var urlWithEndpoint = this.ApplyBaseUrl(endpoint);
+
+            var parsedResult = await this.GetEmptyActivitiesFromUrl(identity, urlWithEndpoint);
+
+            return parsedResult;
+        }
+
+        public async Task<EmptyActivityList> GetWaitingEmptyActivitiesByIdentity(IIdentity identity)
+        {
+            var endpoint = RestSettings.Paths.GetOwnEmptyActivities;
+
+            var urlWithEndpoint = this.ApplyBaseUrl(endpoint);
+
+            var parsedResult = await this.GetEmptyActivitiesFromUrl(identity, urlWithEndpoint);
+
+            return parsedResult;
+        }
+
+        public async Task FinishEmptyActivity(IIdentity identity, string processInstanceId, string correlationId, string emptyActivityInstanceId)
+        {
+            var endpoint = RestSettings.Paths.FinishEmptyActivity
+                .Replace(RestSettings.Params.ProcessInstanceId, processInstanceId)
+                .Replace(RestSettings.Params.CorrelationId, correlationId)
+                .Replace(RestSettings.Params.EmptyActivityInstanceId, emptyActivityInstanceId);
+
+            var urlWithEndpoint = this.ApplyBaseUrl(endpoint);
+
+            var request = this.CreateRequestMessage(identity, HttpMethod.Post, urlWithEndpoint);
+            var result = await this.httpClient.SendAsync(request);
+
+            if (!result.IsSuccessStatusCode)
+            {
+                throw new Exception($"Failed to finish EmptyActivity: {result.ReasonPhrase}");
+            }
+        }
+
         public async Task<UserTaskList> GetUserTasksForProcessModel(IIdentity identity, string processModelId)
         {
             var endpoint = RestSettings.Paths.ProcessModelUserTasks
@@ -366,6 +444,13 @@
             return result;
         }
 
+        private async Task<EmptyActivityList> GetEmptyActivitiesFromUrl(IIdentity identity, string url, HttpContent content = null)
+        {
+            var result = await this.SendRequestAndExpectResult<EmptyActivityList>(identity, HttpMethod.Get, url, content);
+
+            return result;
+        }
+
         private async Task<ManualTaskList> GetManualTasksFromUrl(IIdentity identity, string url, HttpContent content = null)
         {
             var result = await this.SendRequestAndExpectResult<ManualTaskList>(identity, HttpMethod.Get, url, content);
@@ -436,5 +521,5 @@
             var jsonPayload = JsonConvert.SerializeObject(payload, serializerSettings);
             return jsonPayload;
         }
-    }
+  }
 }

--- a/dotnet/src/ConsumerApiClientService.cs
+++ b/dotnet/src/ConsumerApiClientService.cs
@@ -191,7 +191,7 @@
 
         public async Task<EmptyActivityList> GetEmptyActivitiesForProcessModel(IIdentity identity, string processModelId)
         {
-            var endpoint = RestSettings.Paths.ProcessInstanceEmptyActivities
+            var endpoint = RestSettings.Paths.ProcessModelEmptyActivities
                 .Replace(RestSettings.Params.ProcessModelId, processModelId);
 
             var parsedResult = await this.GetEmptyActivitiesFromUrl(identity, endpoint);

--- a/dotnet/src/ConsumerApiClientService.cs
+++ b/dotnet/src/ConsumerApiClientService.cs
@@ -10,7 +10,6 @@
     using EssentialProjects.IAM.Contracts;
 
     using ProcessEngine.ConsumerAPI.Contracts;
-    using ProcessEngine.ConsumerAPI.Contracts.APIs;
     using ProcessEngine.ConsumerAPI.Contracts.DataModel;
 
     using RestSettings = ProcessEngine.ConsumerAPI.Contracts.RestSettings;

--- a/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
+++ b/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>ProcessEngine.ConsumerAPI.Client</RootNamespace>
     <AssemblyName>ProcessEngine.ConsumerAPI.Client</AssemblyName>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Authors>Sebastian Meier;</Authors>
+    <Authors>Christian Werner;Sebastian Meier;</Authors>
     <Company>5Minds IT-Solutions GmbH &amp; Co. KG</Company>
     <Description />
     <Copyright>Copyright © 5Minds IT-Solutions GmbH &amp; Co. KG 2018</Copyright>

--- a/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
+++ b/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="11.0.0" />
+    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="12.0.0-feature-implement-dotnet-empty-activity-api" />
     <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
   </ItemGroup>
 

--- a/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
+++ b/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="12.0.0-feature-implement-dotnet-empty-activity-api" />
+    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="12.0.0" />
     <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
   </ItemGroup>
 

--- a/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
+++ b/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <RootNamespace>ProcessEngine.ConsumerAPI.Client</RootNamespace>
     <AssemblyName>ProcessEngine.ConsumerAPI.Client</AssemblyName>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/dotnet/tests/ConsumerAPIService/EmptyActivites/FinishEmptyActivityTests.cs
+++ b/dotnet/tests/ConsumerAPIService/EmptyActivites/FinishEmptyActivityTests.cs
@@ -1,0 +1,79 @@
+namespace ProcessEngine.ConsumerAPI.Client.Tests
+{
+  using System.Linq;
+  using System.Threading.Tasks;
+  using System;
+
+  using ProcessEngine.ConsumerAPI.Client.Tests.xUnit;
+  using ProcessEngine.ConsumerAPI.Contracts.DataModel;
+
+  using Xunit;
+
+  [Collection("ConsumerAPI collection")]
+    public class FinishEmptyActivityTests : ProcessEngineBaseTest
+    {
+        private readonly ConsumerAPIFixture fixture;
+
+        public FinishEmptyActivityTests(ConsumerAPIFixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact]
+        public void FinishEmptyActivity_EmptyParameters_ShouldThrowException()
+        {
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await this
+                .fixture
+                .ConsumerAPIClient
+                .FinishEmptyActivity(this.fixture.DefaultIdentity, "", "", "")
+            );
+        }
+
+        [Fact]
+        public void FinishEmptyActivity_ProcessInstanceNotFound_ShouldThrowException()
+        {
+            Assert.ThrowsAsync<Exception>(async () => await this
+                .fixture
+                .ConsumerAPIClient
+                .FinishEmptyActivity( this.fixture.DefaultIdentity, "abc", "", "")
+            );
+        }
+
+        [Fact]
+        public async Task BPMN_FinishEmptyActivity_ShouldFinishEmptyActivity()
+        {
+            var processModelId = "test_consumer_api_emptyactivity";
+            var identity = this.fixture.DefaultIdentity;
+            var payload = new ProcessStartRequestPayload<object>();
+            var callbackType = StartCallbackType.CallbackOnProcessInstanceCreated;
+
+            var processInstance = await this
+                .fixture
+                .ConsumerAPIClient
+                .StartProcessInstance(identity, processModelId, "StartEvent_1", payload, callbackType);
+
+            // Give the ProcessEngine time to reach the EmptyActivity
+            await Task.Delay(1000);
+
+            var emptyActivities = await this
+                .fixture
+                .ConsumerAPIClient
+                .GetEmptyActivitiesForCorrelation(identity, processInstance.CorrelationId);
+
+            Assert.NotEmpty(emptyActivities.EmptyActivities);
+
+            var emptyActivityToBeFinished = emptyActivities.EmptyActivities.ElementAt(0);
+
+            await this
+                .fixture
+                .ConsumerAPIClient
+                .FinishEmptyActivity(
+                    identity,
+                    processInstance.ProcessInstanceId,
+                    processInstance.CorrelationId,
+                    emptyActivityToBeFinished.FlowNodeInstanceId
+                );
+        }
+
+    }
+}

--- a/dotnet/tests/ConsumerAPIService/EmptyActivites/GetEmptyActivitiesByIdentityTests.cs
+++ b/dotnet/tests/ConsumerAPIService/EmptyActivites/GetEmptyActivitiesByIdentityTests.cs
@@ -1,0 +1,41 @@
+namespace ProcessEngine.ConsumerAPI.Client.Tests
+{
+  using System.Threading.Tasks;
+
+  using ProcessEngine.ConsumerAPI.Client.Tests.xUnit;
+  using ProcessEngine.ConsumerAPI.Contracts.DataModel;
+
+  using Xunit;
+
+  [Collection("ConsumerAPI collection")]
+    public class GetWaitingEmptyActivitiesByIdentityTests : ProcessEngineBaseTest
+    {
+        private readonly ConsumerAPIFixture fixture;
+
+        public GetWaitingEmptyActivitiesByIdentityTests(ConsumerAPIFixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact]
+        public async Task BPMN_GetWaitingEmptyActivitiesByIdentity_ShouldFetchEmptyActivityList()
+        {
+            var processModelId = "test_consumer_api_emptyactivity";
+            var payload = new ProcessStartRequestPayload<object>();
+            var callbackType = StartCallbackType.CallbackOnProcessInstanceCreated;
+
+            var processInstance = await this
+                .fixture
+                .ConsumerAPIClient
+                .StartProcessInstance(this.fixture.DefaultIdentity, processModelId, "StartEvent_1", payload, callbackType);
+
+            // Give the ProcessEngine time to reach the EmptyActivity
+            await Task.Delay(2000);
+
+            var emptyActivities = await this.fixture.ConsumerAPIClient.GetWaitingEmptyActivitiesByIdentity(this.fixture.DefaultIdentity);
+
+            Assert.NotEmpty(emptyActivities.EmptyActivities);
+        }
+
+    }
+}

--- a/dotnet/tests/ConsumerAPIService/EmptyActivites/GetEmptyActivitiesForCorrelationTests.cs
+++ b/dotnet/tests/ConsumerAPIService/EmptyActivites/GetEmptyActivitiesForCorrelationTests.cs
@@ -1,0 +1,63 @@
+namespace ProcessEngine.ConsumerAPI.Client.Tests
+{
+  using System.Threading.Tasks;
+  using System;
+
+  using ProcessEngine.ConsumerAPI.Client.Tests.xUnit;
+  using ProcessEngine.ConsumerAPI.Contracts.DataModel;
+
+  using Xunit;
+
+  [Collection("ConsumerAPI collection")]
+    public class GetEmptyActivitiesForCorrelationTests : ProcessEngineBaseTest
+    {
+        private readonly ConsumerAPIFixture fixture;
+
+        public GetEmptyActivitiesForCorrelationTests(ConsumerAPIFixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact]
+        public void GetEmptyActivitiesForCorrelation_EmptyParameters_ShouldThrowException()
+        {
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await this
+                .fixture
+                .ConsumerAPIClient
+                .GetEmptyActivitiesForCorrelation(this.fixture.DefaultIdentity, "")
+            );
+        }
+
+        [Fact]
+        public void GetEmptyActivitiesForCorrelation_ProcessModelNotFound_ShouldThrowException()
+        {
+            Assert.ThrowsAsync<Exception>(async () => await this
+                .fixture
+                .ConsumerAPIClient
+                .GetEmptyActivitiesForCorrelation(this.fixture.DefaultIdentity, "Test"));
+        }
+
+        [Fact]
+        public async Task BPMN_GetEmptyActivitiesForCorrelation_ShouldFetchEmptyActivityList()
+        {
+            var processModelId = "test_consumer_api_emptyactivity";
+            var payload = new ProcessStartRequestPayload<object>();
+            var callbackType = StartCallbackType.CallbackOnProcessInstanceCreated;
+
+            var processInstance = await this
+                .fixture
+                .ConsumerAPIClient
+                .StartProcessInstance(this.fixture.DefaultIdentity, processModelId, "StartEvent_1", payload, callbackType);
+
+            // Give the ProcessEngine time to reach the EmptyActivity
+            await Task.Delay(1000);
+
+            var emptyActivities = await this
+                .fixture
+                .ConsumerAPIClient
+                .GetEmptyActivitiesForCorrelation(this.fixture.DefaultIdentity, processInstance.CorrelationId);
+
+            Assert.NotEmpty(emptyActivities.EmptyActivities);
+        }
+    }
+}

--- a/dotnet/tests/ConsumerAPIService/EmptyActivites/GetEmptyActivitiesForProcessInstanceTests.cs
+++ b/dotnet/tests/ConsumerAPIService/EmptyActivites/GetEmptyActivitiesForProcessInstanceTests.cs
@@ -1,0 +1,44 @@
+namespace ProcessEngine.ConsumerAPI.Client.Tests
+{
+  using System.Threading.Tasks;
+
+  using ProcessEngine.ConsumerAPI.Client.Tests.xUnit;
+  using ProcessEngine.ConsumerAPI.Contracts.DataModel;
+
+  using Xunit;
+
+  [Collection("ConsumerAPI collection")]
+    public class GetEmptyActivitiesForProcessInstanceTests : ProcessEngineBaseTest
+    {
+        private readonly ConsumerAPIFixture fixture;
+
+        public GetEmptyActivitiesForProcessInstanceTests(ConsumerAPIFixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact]
+        public async Task BPMN_GetEmptyActivitiesForProcessInstance_ShouldFetchEmptyActivityList()
+        {
+            var processModelId = "test_consumer_api_emptyactivity";
+            var payload = new ProcessStartRequestPayload<object>();
+            var callbackType = StartCallbackType.CallbackOnProcessInstanceCreated;
+
+            var processInstance = await this
+                .fixture
+                .ConsumerAPIClient
+                .StartProcessInstance(this.fixture.DefaultIdentity, processModelId, "StartEvent_1", payload, callbackType);
+
+            // Give the ProcessEngine time to reach the EmptyActivity
+            await Task.Delay(1000);
+
+            var emptyActivities = await this
+                .fixture
+                .ConsumerAPIClient
+                .GetEmptyActivitiesForProcessInstance(this.fixture.DefaultIdentity, processInstance.ProcessInstanceId);
+
+            Assert.NotEmpty(emptyActivities.EmptyActivities);
+        }
+
+    }
+}

--- a/dotnet/tests/ConsumerAPIService/EmptyActivites/GetEmptyActivitiesForProcessModelInCorrelationTests.cs
+++ b/dotnet/tests/ConsumerAPIService/EmptyActivites/GetEmptyActivitiesForProcessModelInCorrelationTests.cs
@@ -1,0 +1,44 @@
+namespace ProcessEngine.ConsumerAPI.Client.Tests
+{
+  using System.Threading.Tasks;
+
+  using ProcessEngine.ConsumerAPI.Client.Tests.xUnit;
+  using ProcessEngine.ConsumerAPI.Contracts.DataModel;
+
+  using Xunit;
+
+  [Collection("ConsumerAPI collection")]
+    public class GetEmptyActivitiesForProcessModelInCorrelationTests : ProcessEngineBaseTest
+    {
+        private readonly ConsumerAPIFixture fixture;
+
+        public GetEmptyActivitiesForProcessModelInCorrelationTests(ConsumerAPIFixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact]
+        public async Task BPMN_GetEmptyActivitiesForProcessModelInCorrelation_ShouldFetchEmptyActivityList()
+        {
+            var processModelId = "test_consumer_api_emptyactivity";
+            var payload = new ProcessStartRequestPayload<object>();
+            var callbackType = StartCallbackType.CallbackOnProcessInstanceCreated;
+
+            var processInstance = await this
+                .fixture
+                .ConsumerAPIClient
+                .StartProcessInstance(this.fixture.DefaultIdentity, processModelId, "StartEvent_1", payload, callbackType);
+
+            // Give the ProcessEngine time to reach the EmptyActivity
+            await Task.Delay(1000);
+
+            var emptyActivities = await this
+                .fixture
+                .ConsumerAPIClient
+                .GetEmptyActivitiesForProcessModelInCorrelation(this.fixture.DefaultIdentity, processModelId, processInstance.CorrelationId);
+
+            Assert.NotEmpty(emptyActivities.EmptyActivities);
+        }
+
+    }
+}

--- a/dotnet/tests/ConsumerAPIService/EmptyActivites/GetEmptyActivitiesForProcessModelTests.cs
+++ b/dotnet/tests/ConsumerAPIService/EmptyActivites/GetEmptyActivitiesForProcessModelTests.cs
@@ -1,0 +1,44 @@
+namespace ProcessEngine.ConsumerAPI.Client.Tests
+{
+  using System.Threading.Tasks;
+
+  using ProcessEngine.ConsumerAPI.Client.Tests.xUnit;
+  using ProcessEngine.ConsumerAPI.Contracts.DataModel;
+
+  using Xunit;
+
+  [Collection("ConsumerAPI collection")]
+    public class GetEmptyActivitiesForProcessModelTests : ProcessEngineBaseTest
+    {
+        private readonly ConsumerAPIFixture fixture;
+
+        public GetEmptyActivitiesForProcessModelTests(ConsumerAPIFixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact]
+        public async Task BPMN_GetEmptyActivitiesForProcessModel_ShouldFetchEmptyActivityList()
+        {
+            var processModelId = "test_consumer_api_emptyactivity";
+            var payload = new ProcessStartRequestPayload<object>();
+            var callbackType = StartCallbackType.CallbackOnProcessInstanceCreated;
+
+            var processInstance = await this
+                .fixture
+                .ConsumerAPIClient
+                .StartProcessInstance(this.fixture.DefaultIdentity, processModelId, "StartEvent_1", payload, callbackType);
+
+            // Give the ProcessEngine time to reach the EmptyActivity
+            await Task.Delay(1000);
+
+            var emptyActivities = await this
+                .fixture
+                .ConsumerAPIClient
+                .GetEmptyActivitiesForProcessModel(this.fixture.DefaultIdentity, processModelId);
+
+            Assert.NotEmpty(emptyActivities.EmptyActivities);
+        }
+
+    }
+}

--- a/dotnet/tests/ConsumerAPIService/ProcessEngineBaseTest.cs
+++ b/dotnet/tests/ConsumerAPIService/ProcessEngineBaseTest.cs
@@ -1,19 +1,8 @@
 namespace ProcessEngine.ConsumerAPI.Client.Tests
 {
-    using System.Collections.Generic;
-    using System.Net.Http.Headers;
-    using System.Net.Http;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System;
+  using System;
 
-    using EssentialProjects.IAM.Contracts;
-
-    using ProcessEngine.ConsumerAPI.Contracts;
-
-    using Newtonsoft.Json;
-
-    public class ProcessEngineBaseTest
+  public class ProcessEngineBaseTest
     {
         private string processEngineRestApiUrl;
 

--- a/dotnet/tests/ProcessEngine.ConsumerAPI.Client.Tests.csproj
+++ b/dotnet/tests/ProcessEngine.ConsumerAPI.Client.Tests.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="12.0.0-feature-implement-dotnet-empty-activity-api" />
+    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="12.0.0" />
     <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="xunit" Version="2.4.0" />

--- a/dotnet/tests/ProcessEngine.ConsumerAPI.Client.Tests.csproj
+++ b/dotnet/tests/ProcessEngine.ConsumerAPI.Client.Tests.csproj
@@ -18,6 +18,9 @@
     <None Update="bpmn\test_consumer_api_correlation_result.bpmn">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="bpmn\test_consumer_api_emptyactivity.bpmn">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="bpmn\test_start_process.bpmn">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/dotnet/tests/ProcessEngine.ConsumerAPI.Client.Tests.csproj
+++ b/dotnet/tests/ProcessEngine.ConsumerAPI.Client.Tests.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="11.0.0" />
+    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="12.0.0-feature-implement-dotnet-empty-activity-api" />
     <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="xunit" Version="2.4.0" />

--- a/dotnet/tests/bpmn/test_consumer_api_emptyactivity.bpmn
+++ b/dotnet/tests/bpmn/test_consumer_api_emptyactivity.bpmn
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definition_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="BPMN Studio" exporterVersion="1">
+  <bpmn:collaboration id="Collaboration_1cidyxu" name="">
+    <bpmn:participant id="Participant_0px403d" name="test_consumer_api_emptyactivity" processRef="test_consumer_api_emptyactivity" />
+  </bpmn:collaboration>
+  <bpmn:process id="test_consumer_api_emptyactivity" name="test_consumer_api_emptyactivity" isExecutable="true">
+    <bpmn:laneSet>
+      <bpmn:lane id="Lane_1xzf0d3" name="Default_Test_Lane">
+        <bpmn:flowNodeRef>StartEvent_1</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_0gmd1s3</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>EndEvent_1</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+    <bpmn:startEvent id="StartEvent_1" name="Start Event">
+      <bpmn:outgoing>SequenceFlow_1fotkzw</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1fotkzw" sourceRef="StartEvent_1" targetRef="Task_0gmd1s3" />
+    <bpmn:sequenceFlow id="SequenceFlow_1889f4o" sourceRef="Task_0gmd1s3" targetRef="EndEvent_1" />
+    <bpmn:task id="Task_0gmd1s3" name="Empty Activity">
+      <bpmn:incoming>SequenceFlow_1fotkzw</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1889f4o</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:endEvent id="EndEvent_1" name="End Event">
+      <bpmn:incoming>SequenceFlow_1889f4o</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1cidyxu">
+      <bpmndi:BPMNShape id="Participant_0px403d_di" bpmnElement="Participant_0px403d">
+        <dc:Bounds x="5" y="4" width="403" height="170" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_1xzf0d3_di" bpmnElement="Lane_1xzf0d3">
+        <dc:Bounds x="35" y="4" width="373" height="170" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_1mox3jl_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="83" y="69" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="74" y="105" width="55" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0eie6q6_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="344" y="69" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="337" y="105" width="51" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1fotkzw_di" bpmnElement="SequenceFlow_1fotkzw">
+        <di:waypoint x="119" y="87" />
+        <di:waypoint x="169" y="87" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1889f4o_di" bpmnElement="SequenceFlow_1889f4o">
+        <di:waypoint x="269" y="87" />
+        <di:waypoint x="344" y="87" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Task_1e5jlub_di" bpmnElement="Task_0gmd1s3">
+        <dc:Bounds x="169" y="47" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Changes

1. Add UseCases for accessing the ConsumerAPI's `EmptyActivityApi`
2. Some internal refactoring for the .NET client
3. Add tests for retrieving and finishing `EmptyActivities` through the .NET client.

## Issues

PR: #52