### PR TITLE
✨Add missing UseCases to .NET Client

### DIFF
--- a/dotnet/src/ConsumerApiClientService.cs
+++ b/dotnet/src/ConsumerApiClientService.cs
@@ -26,6 +26,44 @@
             this.httpClient = httpClient;
         }
 
+        public async Task<ProcessModel> GetProcessModelById(IIdentity identity, string processModelId)
+        {
+            var endpoint = RestSettings.Paths.ProcessModelById
+                .Replace(RestSettings.Params.ProcessModelId, processModelId);
+
+            var parsedResult = await this.GetProcessModelFromUrl(identity, endpoint);
+
+            return parsedResult;
+        }
+
+        public async Task<ProcessModel> GetProcessModelByProcessInstanceId(IIdentity identity, string processInstanceId)
+        {
+            var endpoint = RestSettings.Paths.ProcessModelByProcessInstanceId
+                .Replace(RestSettings.Params.ProcessInstanceId, processInstanceId);
+
+            var parsedResult = await this.GetProcessModelFromUrl(identity, endpoint);
+
+            return parsedResult;
+        }
+
+        public async Task<ProcessModelList> GetProcessModels(IIdentity identity)
+        {
+            var endpoint = RestSettings.Paths.ProcessModels;
+
+            var result = await this.SendRequestAndExpectResult<ProcessModelList>(identity, HttpMethod.Get, endpoint);
+
+            return result;
+        }
+
+        public async Task<IEnumerable<ProcessInstance>> GetProcessInstancesByIdentity(IIdentity identity)
+        {
+            var endpoint = RestSettings.Paths.GetOwnProcessInstances;
+
+            var result = await this.SendRequestAndExpectResult<IEnumerable<ProcessInstance>>(identity, HttpMethod.Get, endpoint);
+
+            return result;
+        }
+
         public async Task<ProcessStartResponsePayload> StartProcessInstance<TInputValues>(
             IIdentity identity,
             string processModelId,
@@ -395,35 +433,37 @@
             }
         }
 
-        private string ApplyBaseUrl(string endpoint)
+        private async Task<ProcessModel> GetProcessModelFromUrl(IIdentity identity, string url)
         {
-            return $"{RestSettings.Endpoints.ConsumerAPI}{endpoint}";
-        }
-
-        private async Task<EventList> GetTriggerableEventsFromUrl(IIdentity identity, string url, HttpContent content = null)
-        {
-            var result = await this.SendRequestAndExpectResult<EventList>(identity, HttpMethod.Get, url, content);
+            var result = await this.SendRequestAndExpectResult<ProcessModel>(identity, HttpMethod.Get, url);
 
             return result;
         }
 
-        private async Task<EmptyActivityList> GetEmptyActivitiesFromUrl(IIdentity identity, string url, HttpContent content = null)
+        private async Task<EventList> GetTriggerableEventsFromUrl(IIdentity identity, string url)
         {
-            var result = await this.SendRequestAndExpectResult<EmptyActivityList>(identity, HttpMethod.Get, url, content);
+            var result = await this.SendRequestAndExpectResult<EventList>(identity, HttpMethod.Get, url);
 
             return result;
         }
 
-        private async Task<ManualTaskList> GetManualTasksFromUrl(IIdentity identity, string url, HttpContent content = null)
+        private async Task<EmptyActivityList> GetEmptyActivitiesFromUrl(IIdentity identity, string url)
         {
-            var result = await this.SendRequestAndExpectResult<ManualTaskList>(identity, HttpMethod.Get, url, content);
+            var result = await this.SendRequestAndExpectResult<EmptyActivityList>(identity, HttpMethod.Get, url);
 
             return result;
         }
 
-        private async Task<UserTaskList> GetUserTasksFromUrl(IIdentity identity, string url, HttpContent content = null)
+        private async Task<ManualTaskList> GetManualTasksFromUrl(IIdentity identity, string url)
         {
-            var result = await this.SendRequestAndExpectResult<UserTaskList>(identity, HttpMethod.Get, url, content);
+            var result = await this.SendRequestAndExpectResult<ManualTaskList>(identity, HttpMethod.Get, url);
+
+            return result;
+        }
+
+        private async Task<UserTaskList> GetUserTasksFromUrl(IIdentity identity, string url)
+        {
+            var result = await this.SendRequestAndExpectResult<UserTaskList>(identity, HttpMethod.Get, url);
 
             return result;
         }
@@ -448,6 +488,11 @@
             }
 
             return parsedResult;
+        }
+
+        private string ApplyBaseUrl(string endpoint)
+        {
+            return $"{RestSettings.Endpoints.ConsumerAPI}{endpoint}";
         }
 
         private HttpRequestMessage CreateRequestMessage(IIdentity identity, HttpMethod method, string url, HttpContent content = null)

--- a/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
+++ b/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="13.0.0-feature-add-missing-use-cases-to-dotnet-client" />
+    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="13.0.0" />
     <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
   </ItemGroup>
 

--- a/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
+++ b/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <RootNamespace>ProcessEngine.ConsumerAPI.Client</RootNamespace>
     <AssemblyName>ProcessEngine.ConsumerAPI.Client</AssemblyName>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="12.0.0" />
+    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="13.0.0-feature-add-missing-use-cases-to-dotnet-client" />
     <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
   </ItemGroup>
 

--- a/dotnet/tests/ConsumerAPIService/ProcessModels/GetProcessInstancesByIdentityTest.cs
+++ b/dotnet/tests/ConsumerAPIService/ProcessModels/GetProcessInstancesByIdentityTest.cs
@@ -1,0 +1,40 @@
+namespace ProcessEngine.ConsumerAPI.Client.Tests
+{
+  using System.Threading.Tasks;
+
+  using ProcessEngine.ConsumerAPI.Client.Tests.xUnit;
+
+  using Xunit;
+  using ProcessEngine.ConsumerAPI.Contracts.DataModel;
+
+  [Collection("ConsumerAPI collection")]
+    public class GetProcessInstancesByIdentity : ProcessEngineBaseTest
+    {
+        private readonly ConsumerAPIFixture fixture;
+
+        public GetProcessInstancesByIdentity(ConsumerAPIFixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact]
+        public async Task BPMN_GetProcessInstancesByIdentity_ShouldGetProcessInstances()
+        {
+            var processModelId = "test_consumer_api_correlation_result";
+            var payload = new ProcessStartRequestPayload<object>();
+            var callbackType = StartCallbackType.CallbackOnProcessInstanceFinished;
+
+            var processInstance = await this
+                .fixture
+                .ConsumerAPIClient
+                .StartProcessInstance(this.fixture.DefaultIdentity, processModelId, "StartEvent_1", payload, callbackType);
+
+            var processInstances = await this
+                .fixture
+                .ConsumerAPIClient
+                .GetProcessInstancesByIdentity(this.fixture.DefaultIdentity);
+
+            Assert.NotNull(processInstances);
+        }
+    }
+}

--- a/dotnet/tests/ConsumerAPIService/ProcessModels/GetProcessModelByIdTest.cs
+++ b/dotnet/tests/ConsumerAPIService/ProcessModels/GetProcessModelByIdTest.cs
@@ -1,0 +1,45 @@
+namespace ProcessEngine.ConsumerAPI.Client.Tests
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Threading;
+    using System;
+
+    using EssentialProjects.IAM.Contracts;
+
+    using ProcessEngine.ConsumerAPI.Client.Tests.xUnit;
+    using ProcessEngine.ConsumerAPI.Contracts;
+
+    using Xunit;
+    using ProcessEngine.ConsumerAPI.Contracts.DataModel;
+
+    [Collection("ConsumerAPI collection")]
+    public class GetProcessModelByIdTest : ProcessEngineBaseTest
+    {
+        private readonly ConsumerAPIFixture fixture;
+
+        public GetProcessModelByIdTest(ConsumerAPIFixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact]
+        public async Task BPMN_GetProcessModelByIdTest_ShouldGetProcessModel()
+        {
+            var processModelId = "test_consumer_api_correlation_result";
+
+            var processModel = await this
+                .fixture
+                .ConsumerAPIClient
+                .GetProcessModelById(this.fixture.DefaultIdentity, processModelId);
+
+            Assert.NotNull(processModel);
+
+            Assert.Equal(processModel.ID, processModelId);
+            Assert.Equal(processModel.StartEvents.ToList()[0].Id, "StartEvent_1");
+            Assert.Equal(processModel.EndEvents.ToList()[0].Id, "EndEvent_Success");
+        }
+    }
+}

--- a/dotnet/tests/ConsumerAPIService/ProcessModels/GetProcessModelByProcessInstanceIdTest.cs
+++ b/dotnet/tests/ConsumerAPIService/ProcessModels/GetProcessModelByProcessInstanceIdTest.cs
@@ -1,0 +1,48 @@
+namespace ProcessEngine.ConsumerAPI.Client.Tests
+{
+  using System;
+  using System.Linq;
+  using System.Threading.Tasks;
+
+  using ProcessEngine.ConsumerAPI.Client.Tests.xUnit;
+
+  using Xunit;
+  using ProcessEngine.ConsumerAPI.Contracts.DataModel;
+
+  [Collection("ConsumerAPI collection")]
+    public class GetProcessModelByProcessInstanceId : ProcessEngineBaseTest
+    {
+        private readonly ConsumerAPIFixture fixture;
+
+        public GetProcessModelByProcessInstanceId(ConsumerAPIFixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact]
+        public async Task BPMN_GetProcessModelByProcessInstanceId_ShouldGetProcessModel()
+        {
+            var processModelId = "test_consumer_api_correlation_result";
+            var payload = new ProcessStartRequestPayload<object>();
+            var callbackType = StartCallbackType.CallbackOnProcessInstanceFinished;
+
+            var processStartResponsePayload = await this
+                .fixture
+                .ConsumerAPIClient
+                .StartProcessInstance(this.fixture.DefaultIdentity, processModelId, "StartEvent_1", payload, callbackType);
+
+            Assert.NotNull(processStartResponsePayload);
+
+            var processModel = await this
+                .fixture
+                .ConsumerAPIClient
+                .GetProcessModelByProcessInstanceId(this.fixture.DefaultIdentity, processStartResponsePayload.ProcessInstanceId);
+
+            Assert.NotNull(processModel);
+
+            Assert.Equal(processModelId, processModel.ID);
+            Assert.Equal("StartEvent_1", processModel.StartEvents.ToList()[0].Id);
+            Assert.Equal("EndEvent_Success", processModel.EndEvents.ToList()[0].Id);
+        }
+    }
+}

--- a/dotnet/tests/ConsumerAPIService/ProcessModels/GetProcessModelsTest.cs
+++ b/dotnet/tests/ConsumerAPIService/ProcessModels/GetProcessModelsTest.cs
@@ -1,0 +1,30 @@
+namespace ProcessEngine.ConsumerAPI.Client.Tests
+{
+  using System.Threading.Tasks;
+
+  using ProcessEngine.ConsumerAPI.Client.Tests.xUnit;
+
+  using Xunit;
+
+  [Collection("ConsumerAPI collection")]
+    public class GetProcessModels : ProcessEngineBaseTest
+    {
+        private readonly ConsumerAPIFixture fixture;
+
+        public GetProcessModels(ConsumerAPIFixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact]
+        public async Task BPMN_GetProcessModels_ShouldGetProcessModels()
+        {
+            var processModels = await this
+                .fixture
+                .ConsumerAPIClient
+                .GetProcessModels(this.fixture.DefaultIdentity);
+
+            Assert.NotEmpty(processModels.ProcessModels);
+        }
+    }
+}

--- a/dotnet/tests/ConsumerAPIService/ProcessModels/GetProcessResultForCorrelationTests.cs
+++ b/dotnet/tests/ConsumerAPIService/ProcessModels/GetProcessResultForCorrelationTests.cs
@@ -1,21 +1,15 @@
 namespace ProcessEngine.ConsumerAPI.Client.Tests
 {
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Threading;
-    using System;
+  using System.Collections.Generic;
+  using System.Linq;
+  using System.Threading.Tasks;
 
-    using EssentialProjects.IAM.Contracts;
+  using ProcessEngine.ConsumerAPI.Client.Tests.xUnit;
 
-    using ProcessEngine.ConsumerAPI.Client.Tests.xUnit;
-    using ProcessEngine.ConsumerAPI.Contracts;
+  using Xunit;
+  using ProcessEngine.ConsumerAPI.Contracts.DataModel;
 
-    using Xunit;
-    using ProcessEngine.ConsumerAPI.Contracts.DataModel;
-
-    [Collection("ConsumerAPI collection")]
+  [Collection("ConsumerAPI collection")]
     public class GetProcessResultForCorrelationTests : ProcessEngineBaseTest
     {
         private readonly ConsumerAPIFixture fixture;

--- a/dotnet/tests/ConsumerAPIService/ProcessModels/StartProcessInstanceTests.cs
+++ b/dotnet/tests/ConsumerAPIService/ProcessModels/StartProcessInstanceTests.cs
@@ -1,20 +1,14 @@
 namespace ProcessEngine.ConsumerAPI.Client.Tests
 {
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System;
+  using System.Threading.Tasks;
+  using System;
 
-    using EssentialProjects.IAM.Contracts;
+  using ProcessEngine.ConsumerAPI.Client.Tests.xUnit;
 
-    using ProcessEngine.ConsumerAPI.Client.Tests.xUnit;
-    using ProcessEngine.ConsumerAPI.Contracts;
+  using Xunit;
+  using ProcessEngine.ConsumerAPI.Contracts.DataModel;
 
-    using Xunit;
-    using ProcessEngine.ConsumerAPI.Contracts.DataModel;
-
-    [Collection("ConsumerAPI collection")]
+  [Collection("ConsumerAPI collection")]
     public class StartProcessInstanceTests : ProcessEngineBaseTest
     {
         private readonly ConsumerAPIFixture fixture;

--- a/dotnet/tests/ProcessEngine.ConsumerAPI.Client.Tests.csproj
+++ b/dotnet/tests/ProcessEngine.ConsumerAPI.Client.Tests.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="13.0.0-feature-add-missing-use-cases-to-dotnet-client" />
+    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="13.0.0" />
     <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="xunit" Version="2.4.0" />

--- a/dotnet/tests/ProcessEngine.ConsumerAPI.Client.Tests.csproj
+++ b/dotnet/tests/ProcessEngine.ConsumerAPI.Client.Tests.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="12.0.0" />
+    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="13.0.0-feature-add-missing-use-cases-to-dotnet-client" />
     <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="xunit" Version="2.4.0" />


### PR DESCRIPTION
## Changes

Implement some UseCases that were included with the .TS Client, but not here.
This mostly includes UseCases for retrieving ProcessModels.

## Issues

PR: #53

## How to test the Changes

Use the Client to call any of the newly implemented endpoints.