### PR TITLE
✨Import ExternalTaskApi

### DIFF
--- a/dotnet/src/ExternalTaskWorker.cs
+++ b/dotnet/src/ExternalTaskWorker.cs
@@ -188,7 +188,7 @@ namespace ProcessEngine.ConsumerAPI.Client
             }
             else
             {
-                await this.externalTaskApi.FinishExternalTask(identity, this.WorkerId, externalTaskId, result);
+                await this.externalTaskApi.FinishExternalTask(identity, this.WorkerId, externalTaskId, (result as ExternalTaskSuccessResult<object>).result);
             }
         }
     }

--- a/dotnet/src/ExternalTaskWorker.cs
+++ b/dotnet/src/ExternalTaskWorker.cs
@@ -1,0 +1,195 @@
+namespace ProcessEngine.ConsumerAPI.Client
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    using EssentialProjects.IAM.Contracts;
+
+    using ProcessEngine.ConsumerAPI.Contracts;
+    using ProcessEngine.ConsumerAPI.Contracts.DataModel;
+    using ProcessEngine.ConsumerAPI.Contracts.APIs;
+
+    /// <summary>
+    /// Periodically fetches, locks and processes ExternalTasks for a given topic.
+    /// </summary>
+    public class ExternalTaskWorker : IExternalTaskWorker
+    {
+        private const int LockDurationInMilliseconds = 30000;
+
+        private readonly IExternalTaskConsumerApi externalTaskApi;
+
+        /// <summary>
+        /// Creates an new instance of ExternalTaskWorker
+        /// </summary>
+        public ExternalTaskWorker(IExternalTaskConsumerApi externalTaskApi)
+        {
+            this.externalTaskApi = externalTaskApi;
+        }
+
+        /// <summary>
+        /// The ID of the worker
+        /// </summary>
+        public string WorkerId { get; } = Guid.NewGuid().ToString();
+
+        /// <summary>
+        /// Periodically fetches, locks and processes available ExternalTasks with a given topic,
+        /// using the given callback as a processing function.
+        /// </summary>
+        /// <param name="identity">
+        /// The identity to use for fetching and processing ExternalTasks.
+        /// </param>
+        /// <param name="topic">
+        /// The topic by which to look for and process ExternalTasks.
+        /// </param>
+        /// <param name="maxTasks">
+        /// max. ExternalTasks to fetch.
+        /// </param>
+        /// <param name="longpollingTimeout">
+        /// Longpolling Timeout in ms.
+        /// </param>
+        /// <param name="handleAction">
+        /// The function for processing the ExternalTasks.
+        /// </param>
+        public async Task WaitForHandle<TPayload>(
+            IIdentity identity,
+            string topic,
+            int maxTasks,
+            int longpollingTimeout,
+            HandleExternalTaskAction<TPayload> handleAction
+        )
+            where TPayload : new()
+        {
+            const bool keepPolling = true;
+            while (keepPolling)
+            {
+                var externalTasks = await this.FetchAndLockExternalTasks<TPayload>(
+                    identity,
+                    topic,
+                    maxTasks,
+                    longpollingTimeout
+                );
+
+                if (externalTasks.Count() == 0)
+                {
+                    Thread.Sleep(1000);
+                    continue;
+                }
+
+                var tasks = new List<Task>();
+
+                foreach (var externalTask in externalTasks)
+                {
+                    tasks.Add(this.ExecuteExternalTask<TPayload>(identity, externalTask, handleAction));
+                }
+
+                await Task.WhenAll(tasks);
+            }
+        }
+
+        private async Task<IEnumerable<ExternalTask<TPayload>>> FetchAndLockExternalTasks<TPayload>(
+            IIdentity identity,
+            string topic,
+            int maxTasks,
+            int longpollingTimeout
+        )
+        where TPayload : new()
+        {
+            try
+            {
+                return await this.externalTaskApi.FetchAndLockExternalTasks<TPayload>(
+                  identity,
+                  WorkerId,
+                  topic,
+                  maxTasks,
+                  longpollingTimeout,
+                  LockDurationInMilliseconds
+                );
+            }
+            catch (Exception exception)
+            {
+                Console.WriteLine(exception);
+
+                // Returning an empty Array here, since "waitForAndHandle" already implements a timeout, in case no tasks are available for processing.
+                // No need to do that twice.
+                return new List<ExternalTask<TPayload>>();
+            }
+        }
+
+        private async Task ExecuteExternalTask<TPayload>(
+          IIdentity identity,
+          ExternalTask<TPayload> externalTask,
+          HandleExternalTaskAction<TPayload> handleAction
+        )
+          where TPayload : new()
+        {
+            const int lockExtensionBuffer = 5000;
+            const int lockRefreshIntervalInMs = LockDurationInMilliseconds - lockExtensionBuffer;
+
+            var lockRefreshTimer = this.StartExtendLockTimer(identity, externalTask, lockRefreshIntervalInMs);
+
+            try
+            {
+                var result = await handleAction(externalTask);
+
+                lockRefreshTimer.Stop();
+
+                await this.ProcessResult(identity, result, externalTask.Id);
+            }
+            catch (Exception exception)
+            {
+                Console.WriteLine(exception);
+                lockRefreshTimer.Stop();
+                await this.externalTaskApi.HandleServiceError(identity, this.WorkerId, externalTask.Id, exception.Message, exception.StackTrace);
+            }
+        }
+
+        private System.Timers.Timer StartExtendLockTimer<TPayload>(IIdentity identity, ExternalTask<TPayload> externalTask, int intervall)
+        {
+            var timer = new System.Timers.Timer(intervall);
+            timer.Elapsed += async (sender, e) => await ExtendLock<TPayload>(identity, externalTask);
+            timer.Start();
+
+            return timer;
+        }
+
+        private async Task ExtendLock<TPayload>(IIdentity identity, ExternalTask<TPayload> externalTask)
+        {
+            try
+            {
+                await this.externalTaskApi.ExtendLock(identity, this.WorkerId, externalTask.Id, LockDurationInMilliseconds);
+            }
+            catch (Exception error)
+            {
+                // This can happen, if the lock-extension was performed after the task was already finished.
+                // Since this isn't really an error, a warning suffices here.
+                Console.WriteLine($"An error occured while trying to extend the lock for ExternalTask ${externalTask.Id}", error.Message, error.StackTrace);
+            }
+        }
+
+        private async Task ProcessResult(IIdentity identity, ExternalTaskResultBase result, string externalTaskId) {
+
+            if (result is ExternalTaskBpmnError) {
+
+                var bpmnError = result as ExternalTaskBpmnError;
+                await this.externalTaskApi.HandleBpmnError(identity, this.WorkerId, externalTaskId, bpmnError.errorCode);
+
+            }
+            else if (result is ExternalTaskServiceError<object>)
+            {
+
+                var serviceError = result as ExternalTaskServiceError<object>;
+                await this
+                    .externalTaskApi
+                    .HandleServiceError(identity, this.WorkerId, externalTaskId, serviceError.errorMessage, serviceError.errorDetails as string);
+
+            }
+            else
+            {
+                await this.externalTaskApi.FinishExternalTask(identity, this.WorkerId, externalTaskId, result);
+            }
+        }
+    }
+}

--- a/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
+++ b/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="13.0.0" />
+    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="13.0.0-feature-import-external-task-api" />
     <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
   </ItemGroup>
 

--- a/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
+++ b/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="13.0.0-feature-import-external-task-api" />
+    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.0.0-feature-import-external-task-api" />
     <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
   </ItemGroup>
 

--- a/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
+++ b/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.0.0-feature-import-external-task-api" />
+    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.0.0-develop" />
     <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
   </ItemGroup>
 

--- a/dotnet/tests/ProcessEngine.ConsumerAPI.Client.Tests.csproj
+++ b/dotnet/tests/ProcessEngine.ConsumerAPI.Client.Tests.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="13.0.0" />
+    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.0.0-feature-import-external-task-api" />
     <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="xunit" Version="2.4.0" />

--- a/dotnet/tests/ProcessEngine.ConsumerAPI.Client.Tests.csproj
+++ b/dotnet/tests/ProcessEngine.ConsumerAPI.Client.Tests.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.0.0-feature-import-external-task-api" />
+    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.0.0-develop" />
     <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="xunit" Version="2.4.0" />

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -68,9 +68,9 @@
       "integrity": "sha512-BO8rvdz5TAivDqT+I0At55eLe5XORO98rXGIiXl5+p9cXoyh2VMlSJChgAYYZs1DYKBmSTyZCb/Ptk82Hh9S2Q=="
     },
     "@process-engine/consumer_api_contracts": {
-      "version": "8.0.0-94a2de90-b5",
-      "resolved": "https://registry.npmjs.org/@process-engine/consumer_api_contracts/-/consumer_api_contracts-8.0.0-94a2de90-b5.tgz",
-      "integrity": "sha512-VeTCJxo9ombWoVkRk4u/2Mhc2tz8E2NTh1GlDPPOEgZYs9jUyHMVZaVTHf79e146zdD73n6BQbbSi9ZJURFQCw==",
+      "version": "8.0.0-178f6ae9-b25",
+      "resolved": "https://registry.npmjs.org/@process-engine/consumer_api_contracts/-/consumer_api_contracts-8.0.0-178f6ae9-b25.tgz",
+      "integrity": "sha512-030dmkzkrwWcXp2RAX5GkLkPJqmone8CVJVwG8A1JDExlCKdOur7IeuMdf6/RoL3d5fUQRjAK9k09w6Au0tcMg==",
       "requires": {
         "@essential-projects/event_aggregator_contracts": "^4.0.0",
         "@essential-projects/http_contracts": "^2.3.0",
@@ -92,9 +92,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.7.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.0.tgz",
-          "integrity": "sha512-vqcj1MVm2Sla4PpMfYKh1MyDN4D2f/mPIZD7RdAGqEsbE+JxfeqQHHVbRDQ0Nqn8i73gJa1HQ1Pu3+nH4Q0Yiw=="
+          "version": "12.7.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.1.tgz",
+          "integrity": "sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw=="
         }
       }
     },
@@ -107,9 +107,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.7.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.0.tgz",
-          "integrity": "sha512-vqcj1MVm2Sla4PpMfYKh1MyDN4D2f/mPIZD7RdAGqEsbE+JxfeqQHHVbRDQ0Nqn8i73gJa1HQ1Pu3+nH4Q0Yiw=="
+          "version": "12.7.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.1.tgz",
+          "integrity": "sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw=="
         }
       }
     },
@@ -139,9 +139,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.7.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.0.tgz",
-          "integrity": "sha512-vqcj1MVm2Sla4PpMfYKh1MyDN4D2f/mPIZD7RdAGqEsbE+JxfeqQHHVbRDQ0Nqn8i73gJa1HQ1Pu3+nH4Q0Yiw=="
+          "version": "12.7.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.1.tgz",
+          "integrity": "sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw=="
         }
       }
     },
@@ -157,9 +157,9 @@
       "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
     },
     "@types/node": {
-      "version": "10.14.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.14.tgz",
-      "integrity": "sha512-xXD08vZsvpv4xptQXj1+ky22f7ZoKu5ZNI/4l+/BXG3X+XaeZsmaFbbTKuhSE3NjjvRuZFxFf9sQBMXIcZNFMQ=="
+      "version": "10.14.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.15.tgz",
+      "integrity": "sha512-CBR5avlLcu0YCILJiDIXeU2pTw7UK/NIxfC63m7d7CVamho1qDEzXKkOtEauQRPMy6MI8mLozth+JJkas7HY6g=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -184,9 +184,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.7.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.0.tgz",
-          "integrity": "sha512-vqcj1MVm2Sla4PpMfYKh1MyDN4D2f/mPIZD7RdAGqEsbE+JxfeqQHHVbRDQ0Nqn8i73gJa1HQ1Pu3+nH4Q0Yiw=="
+          "version": "12.7.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.1.tgz",
+          "integrity": "sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw=="
         }
       }
     },

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -68,9 +68,9 @@
       "integrity": "sha512-BO8rvdz5TAivDqT+I0At55eLe5XORO98rXGIiXl5+p9cXoyh2VMlSJChgAYYZs1DYKBmSTyZCb/Ptk82Hh9S2Q=="
     },
     "@process-engine/consumer_api_contracts": {
-      "version": "8.0.0-dad26234-b24",
-      "resolved": "https://registry.npmjs.org/@process-engine/consumer_api_contracts/-/consumer_api_contracts-8.0.0-dad26234-b24.tgz",
-      "integrity": "sha512-yM1yWz6e5KCWpuQLq9yNMeOWhWTNNxbP7vuZonk5aE3bgFC9hEWmp+vAlArhn4XXrn67i6xayfVQJ4AP1XqT6w==",
+      "version": "8.0.0-94a2de90-b5",
+      "resolved": "https://registry.npmjs.org/@process-engine/consumer_api_contracts/-/consumer_api_contracts-8.0.0-94a2de90-b5.tgz",
+      "integrity": "sha512-VeTCJxo9ombWoVkRk4u/2Mhc2tz8E2NTh1GlDPPOEgZYs9jUyHMVZaVTHf79e146zdD73n6BQbbSi9ZJURFQCw==",
       "requires": {
         "@essential-projects/event_aggregator_contracts": "^4.0.0",
         "@essential-projects/http_contracts": "^2.3.0",
@@ -78,7 +78,8 @@
         "@types/express": "^4.16.0",
         "@types/node": "^10.12.2",
         "@types/socket.io": "^2.1.0",
-        "@types/socket.io-client": "^1.4.32"
+        "@types/socket.io-client": "^1.4.32",
+        "moment": "^2.24.0"
       }
     },
     "@types/body-parser": {
@@ -91,9 +92,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.6.9",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.9.tgz",
-          "integrity": "sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw=="
+          "version": "12.7.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.0.tgz",
+          "integrity": "sha512-vqcj1MVm2Sla4PpMfYKh1MyDN4D2f/mPIZD7RdAGqEsbE+JxfeqQHHVbRDQ0Nqn8i73gJa1HQ1Pu3+nH4Q0Yiw=="
         }
       }
     },
@@ -106,9 +107,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.6.9",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.9.tgz",
-          "integrity": "sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw=="
+          "version": "12.7.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.0.tgz",
+          "integrity": "sha512-vqcj1MVm2Sla4PpMfYKh1MyDN4D2f/mPIZD7RdAGqEsbE+JxfeqQHHVbRDQ0Nqn8i73gJa1HQ1Pu3+nH4Q0Yiw=="
         }
       }
     },
@@ -138,9 +139,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.6.9",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.9.tgz",
-          "integrity": "sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw=="
+          "version": "12.7.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.0.tgz",
+          "integrity": "sha512-vqcj1MVm2Sla4PpMfYKh1MyDN4D2f/mPIZD7RdAGqEsbE+JxfeqQHHVbRDQ0Nqn8i73gJa1HQ1Pu3+nH4Q0Yiw=="
         }
       }
     },
@@ -183,9 +184,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.6.9",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.9.tgz",
-          "integrity": "sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw=="
+          "version": "12.7.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.0.tgz",
+          "integrity": "sha512-vqcj1MVm2Sla4PpMfYKh1MyDN4D2f/mPIZD7RdAGqEsbE+JxfeqQHHVbRDQ0Nqn8i73gJa1HQ1Pu3+nH4Q0Yiw=="
         }
       }
     },
@@ -332,9 +333,9 @@
       "dev": true
     },
     "async-limiter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "async-middleware": {
       "version": "1.2.1",
@@ -1039,9 +1040,9 @@
       "dev": true
     },
     "graceful-fs": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-      "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
+      "integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==",
       "dev": true
     },
     "has": {
@@ -1085,10 +1086,13 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
-      "dev": true
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.2.tgz",
+      "integrity": "sha512-CyjlXII6LMsPMyUzxpTt8fzh5QwzGqPmQXgY/Jyf4Zfp27t/FvfhwoE/8laaMUcMy816CkWF20I7NeQhwwY88w==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^5.1.1"
+      }
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -1318,6 +1322,15 @@
         "chalk": "^2.1.0"
       }
     },
+    "lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "requires": {
+        "yallist": "^3.0.2"
+      }
+    },
     "make-error": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
@@ -1373,6 +1386,11 @@
       "requires": {
         "minimist": "0.0.8"
       }
+    },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "ms": {
       "version": "2.0.0",
@@ -2014,9 +2032,9 @@
       "dev": true
     },
     "tsutils": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.14.1.tgz",
-      "integrity": "sha512-kiuZzD1uUA5DxGj/uxbde+ymp6VVdAxdzOIlAFbYKrPyla8/uiJ9JLBm1QsPhOm4Muj0/+cWEDP99yoCUcSl6Q==",
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+      "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
@@ -2108,6 +2126,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
       "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
+    },
+    "yallist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+      "dev": true
     },
     "yeast": {
       "version": "0.1.2",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -31,7 +31,7 @@
     "@essential-projects/errors_ts": "^1.5.0",
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/consumer_api_contracts": "feature~import_external_task_api",
+    "@process-engine/consumer_api_contracts": "8.0.0-178f6ae9-b25",
     "async-middleware": "^1.2.1",
     "bluebird": "^3.5.3",
     "loggerhythm": "^3.0.3",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -31,7 +31,7 @@
     "@essential-projects/errors_ts": "^1.5.0",
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/consumer_api_contracts": "8.0.0-dad26234-b24",
+    "@process-engine/consumer_api_contracts": "feature~import_external_task_api",
     "async-middleware": "^1.2.1",
     "bluebird": "^3.5.3",
     "loggerhythm": "^3.0.3",

--- a/typescript/src/accessors/external_accessor.ts
+++ b/typescript/src/accessors/external_accessor.ts
@@ -565,6 +565,93 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     await this.httpClient.post(url, body, requestAuthHeaders);
   }
 
+  // ExternalTasks
+  public async fetchAndLockExternalTasks<TPayloadType>(
+    identity: IIdentity,
+    workerId: string,
+    topicName: string,
+    maxTasks: number,
+    longPollingTimeout: number,
+    lockDuration: number,
+  ): Promise<Array<DataModels.ExternalTask.ExternalTask<TPayloadType>>> {
+
+    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
+
+    let url = restSettings.paths.fetchAndLockExternalTasks;
+    url = this.applyBaseUrl(url);
+
+    const payload = new DataModels.ExternalTask.FetchAndLockRequestPayload(workerId, topicName, maxTasks, longPollingTimeout, lockDuration);
+
+    const httpResponse = await this
+      .httpClient
+      // eslint-disable-next-line max-len
+      .post<DataModels.ExternalTask.FetchAndLockRequestPayload, Array<DataModels.ExternalTask.ExternalTask<TPayloadType>>>(url, payload, requestAuthHeaders);
+
+    return httpResponse.result;
+  }
+
+  public async extendLock(identity: IIdentity, workerId: string, externalTaskId: string, additionalDuration: number): Promise<void> {
+
+    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
+
+    let url = restSettings.paths.extendExternalTaskLock
+      .replace(restSettings.params.externalTaskId, externalTaskId);
+
+    url = this.applyBaseUrl(url);
+
+    const payload = new DataModels.ExternalTask.ExtendLockRequestPayload(workerId, additionalDuration);
+
+    await this.httpClient.post<DataModels.ExternalTask.ExtendLockRequestPayload, void>(url, payload, requestAuthHeaders);
+  }
+
+  public async handleBpmnError(identity: IIdentity, workerId: string, externalTaskId: string, errorCode: string): Promise<void> {
+
+    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
+
+    let url = restSettings.paths.finishExternalTaskWithBpmnError
+      .replace(restSettings.params.externalTaskId, externalTaskId);
+
+    url = this.applyBaseUrl(url);
+
+    const payload = new DataModels.ExternalTask.HandleBpmnErrorRequestPayload(workerId, errorCode);
+
+    await this.httpClient.post<DataModels.ExternalTask.HandleBpmnErrorRequestPayload, void>(url, payload, requestAuthHeaders);
+  }
+
+  public async handleServiceError(
+    identity: IIdentity,
+    workerId: string,
+    externalTaskId: string,
+    errorMessage: string,
+    errorDetails: string,
+  ): Promise<void> {
+
+    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
+
+    let url = restSettings.paths.finishExternalTaskWithServiceError
+      .replace(restSettings.params.externalTaskId, externalTaskId);
+
+    url = this.applyBaseUrl(url);
+
+    const payload = new DataModels.ExternalTask.HandleServiceErrorRequestPayload(workerId, errorMessage, errorDetails);
+
+    await this.httpClient.post<DataModels.ExternalTask.HandleServiceErrorRequestPayload, void>(url, payload, requestAuthHeaders);
+  }
+
+  public async finishExternalTask<TResultType>(identity: IIdentity, workerId: string, externalTaskId: string, results: TResultType): Promise<void> {
+
+    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
+
+    let url = restSettings.paths.finishExternalTask
+      .replace(restSettings.params.externalTaskId, externalTaskId);
+
+    url = this.applyBaseUrl(url);
+
+    const payload = new DataModels.ExternalTask.FinishExternalTaskRequestPayload(workerId, results);
+
+    await this.httpClient.post<DataModels.ExternalTask.FinishExternalTaskRequestPayload<TResultType>, void>(url, payload, requestAuthHeaders);
+  }
+
   // UserTasks
   public async getUserTasksForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.UserTasks.UserTaskList> {
     const requestAuthHeaders = this.createRequestAuthHeaders(identity);

--- a/typescript/src/accessors/internal_accessor.ts
+++ b/typescript/src/accessors/internal_accessor.ts
@@ -12,6 +12,7 @@ export class InternalAccessor implements IConsumerApiAccessor {
 
   private emptyActivityService: APIs.IEmptyActivityConsumerApi;
   private eventService: APIs.IEventConsumerApi;
+  private externalTaskService: APIs.IExternalTaskConsumerApi;
   private manualTaskService: APIs.IManualTaskConsumerApi;
   private notificationService: APIs.INotificationConsumerApi;
   private processModelService: APIs.IProcessModelConsumerApi;
@@ -20,6 +21,7 @@ export class InternalAccessor implements IConsumerApiAccessor {
   constructor(
     emptyActivityService: APIs.IEmptyActivityConsumerApi,
     eventService: APIs.IEventConsumerApi,
+    externalTaskService: APIs.IExternalTaskConsumerApi,
     manualTaskService: APIs.IManualTaskConsumerApi,
     notificationService: APIs.INotificationConsumerApi,
     processModelService: APIs.IProcessModelConsumerApi,
@@ -27,6 +29,7 @@ export class InternalAccessor implements IConsumerApiAccessor {
   ) {
     this.emptyActivityService = emptyActivityService;
     this.eventService = eventService;
+    this.externalTaskService = externalTaskService;
     this.manualTaskService = manualTaskService;
     this.notificationService = notificationService;
     this.processModelService = processModelService;
@@ -132,6 +135,47 @@ export class InternalAccessor implements IConsumerApiAccessor {
     emptyActivityInstanceId: string,
   ): Promise<void> {
     return this.emptyActivityService.finishEmptyActivity(identity, processInstanceId, correlationId, emptyActivityInstanceId);
+  }
+
+  // ExternalTasks
+  public async fetchAndLockExternalTasks<TPayloadType>(
+    identity: IIdentity,
+    workerId: string,
+    topicName: string,
+    maxTasks: number,
+    longPollingTimeout: number,
+    lockDuration: number,
+  ): Promise<Array<DataModels.ExternalTask.ExternalTask<TPayloadType>>> {
+    return this
+      .externalTaskService
+      .fetchAndLockExternalTasks<TPayloadType>(identity, workerId, topicName, maxTasks, longPollingTimeout, lockDuration);
+  }
+
+  public async extendLock(identity: IIdentity, workerId: string, externalTaskId: string, additionalDuration: number): Promise<void> {
+    return this.externalTaskService.extendLock(identity, workerId, externalTaskId, additionalDuration);
+  }
+
+  public async handleBpmnError(identity: IIdentity, workerId: string, externalTaskId: string, errorCode: string): Promise<void> {
+    return this.externalTaskService.handleBpmnError(identity, workerId, externalTaskId, errorCode);
+  }
+
+  public async handleServiceError(
+    identity: IIdentity,
+    workerId: string,
+    externalTaskId: string,
+    errorMessage: string,
+    errorDetails: string,
+  ): Promise<void> {
+    return this.externalTaskService.handleServiceError(identity, workerId, externalTaskId, errorMessage, errorDetails);
+  }
+
+  public async finishExternalTask<TResultType>(
+    identity: IIdentity,
+    workerId: string,
+    externalTaskId: string,
+    payload: TResultType,
+  ): Promise<void> {
+    return this.externalTaskService.finishExternalTask(identity, workerId, externalTaskId, payload);
   }
 
   // ManualTasks

--- a/typescript/src/consumer_api_client.ts
+++ b/typescript/src/consumer_api_client.ts
@@ -436,6 +436,52 @@ export class ConsumerApiClient implements IConsumerApiClient {
     return this.consumerApiAccessor.finishEmptyActivity(identity, processInstanceId, correlationId, emptyActivityInstanceId);
   }
 
+  // ExternalTask
+  public async fetchAndLockExternalTasks<TPayloadType>(
+    identity: IIdentity,
+    workerId: string,
+    topicName: string,
+    maxTasks: number,
+    longPollingTimeout: number,
+    lockDuration: number,
+  ): Promise<Array<DataModels.ExternalTask.ExternalTask<TPayloadType>>> {
+    this.ensureIsAuthorized(identity);
+
+    return this
+      .consumerApiAccessor
+      .fetchAndLockExternalTasks<TPayloadType>(identity, workerId, topicName, maxTasks, longPollingTimeout, lockDuration);
+  }
+
+  public async extendLock(identity: IIdentity, workerId: string, externalTaskId: string, additionalDuration: number): Promise<void> {
+    this.ensureIsAuthorized(identity);
+
+    return this.consumerApiAccessor.extendLock(identity, workerId, externalTaskId, additionalDuration);
+  }
+
+  public async handleBpmnError(identity: IIdentity, workerId: string, externalTaskId: string, errorCode: string): Promise<void> {
+    this.ensureIsAuthorized(identity);
+
+    return this.consumerApiAccessor.handleBpmnError(identity, workerId, externalTaskId, errorCode);
+  }
+
+  public async handleServiceError(
+    identity: IIdentity,
+    workerId: string,
+    externalTaskId: string,
+    errorMessage: string,
+    errorDetails: string,
+  ): Promise<void> {
+    this.ensureIsAuthorized(identity);
+
+    return this.consumerApiAccessor.handleServiceError(identity, workerId, externalTaskId, errorMessage, errorDetails);
+  }
+
+  public async finishExternalTask<TResultType>(identity: IIdentity, workerId: string, externalTaskId: string, payload: TResultType): Promise<void> {
+    this.ensureIsAuthorized(identity);
+
+    return this.consumerApiAccessor.finishExternalTask<TResultType>(identity, workerId, externalTaskId, payload);
+  }
+
   // UserTasks
   public async getUserTasksForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.UserTasks.UserTaskList> {
     this.ensureIsAuthorized(identity);

--- a/typescript/src/external_task_worker.ts
+++ b/typescript/src/external_task_worker.ts
@@ -1,0 +1,145 @@
+import {Logger} from 'loggerhythm';
+import * as uuid from 'node-uuid';
+
+import {IIdentity} from '@essential-projects/iam_contracts';
+
+import {
+  APIs,
+  DataModels,
+  HandleExternalTaskAction,
+  IExternalTaskWorker,
+} from '@process-engine/consumer_api_contracts';
+
+const logger: Logger = Logger.createLogger('processengine:consumer_api:external_task_worker');
+
+export class ExternalTaskWorker implements IExternalTaskWorker {
+
+  // eslint-disable-next-line @typescript-eslint/member-naming
+  private readonly _workerId = uuid.v4();
+  private readonly lockDuration = 30000;
+  private readonly externalTaskService: APIs.IExternalTaskConsumerApi;
+
+  constructor(externalTaskService: APIs.IExternalTaskConsumerApi) {
+    this.externalTaskService = externalTaskService;
+  }
+
+  public get workerId(): string {
+    return this._workerId;
+  }
+
+  public async waitForAndHandle<TPayload>(
+    identity: IIdentity,
+    topic: string,
+    maxTasks: number,
+    longpollingTimeout: number,
+    handleAction: HandleExternalTaskAction<TPayload>,
+  ): Promise<void> {
+
+    const keepPolling = true;
+    while (keepPolling) {
+
+      const externalTasks = await this.fetchAndLockExternalTasks<TPayload>(
+        identity,
+        topic,
+        maxTasks,
+        longpollingTimeout,
+      );
+
+      if (externalTasks.length === 0) {
+        await this.sleep(1000);
+        continue;
+      }
+
+      const executeTaskPromises: Array<Promise<void>> = [];
+
+      for (const externalTask of externalTasks) {
+        executeTaskPromises.push(this.executeExternalTask(identity, externalTask, handleAction));
+      }
+
+      await Promise.all(executeTaskPromises);
+    }
+  }
+
+  private async fetchAndLockExternalTasks<TPayload>(
+    identity: IIdentity,
+    topic: string,
+    maxTasks: number,
+    longpollingTimeout: number,
+  ): Promise<Array<DataModels.ExternalTask.ExternalTask<TPayload>>> {
+
+    try {
+      return await this
+        .externalTaskService
+        .fetchAndLockExternalTasks<TPayload>(identity, this.workerId, topic, maxTasks, longpollingTimeout, this.lockDuration);
+    } catch (error) {
+
+      logger.error(
+        'An error occured during fetchAndLock!',
+        error.message,
+        error.stack,
+      );
+
+      // Returning an empty Array here, since "waitForAndHandle" already implements a timeout, in case no tasks are available for processing.
+      // No need to do that twice.
+      return [];
+    }
+  }
+
+  private async executeExternalTask<TPayload>(
+    identity: IIdentity,
+    externalTask: DataModels.ExternalTask.ExternalTask<TPayload>,
+    handleAction: HandleExternalTaskAction<TPayload>,
+  ): Promise<void> {
+
+    try {
+      const lockExtensionBuffer = 5000;
+
+      const interval =
+        setInterval(async (): Promise<void> => this.extendLocks<TPayload>(identity, externalTask), this.lockDuration - lockExtensionBuffer);
+
+      const result = await handleAction(externalTask);
+      clearInterval(interval);
+
+      if (result instanceof DataModels.ExternalTask.ExternalTaskBpmnError) {
+
+        const bpmnError = result as DataModels.ExternalTask.ExternalTaskBpmnError;
+        await this.externalTaskService.handleBpmnError(identity, this.workerId, externalTask.id, bpmnError.errorCode);
+
+      } else if (result instanceof DataModels.ExternalTask.ExternalTaskServiceError) {
+
+        const serviceError = result as DataModels.ExternalTask.ExternalTaskServiceError;
+        await this
+          .externalTaskService
+          .handleServiceError(identity, this.workerId, externalTask.id, serviceError.errorMessage, serviceError.errorDetails);
+
+      } else {
+
+        const finalResult = result instanceof DataModels.ExternalTask.ExternalTaskSuccessResult
+          ? (result as DataModels.ExternalTask.ExternalTaskSuccessResult<any>).result
+          : result as any;
+
+        await this.externalTaskService.finishExternalTask(identity, this.workerId, externalTask.id, finalResult);
+      }
+    } catch (error) {
+      logger.error('Failed to execute ExternalTask!', error.message, error.stack);
+      await this.externalTaskService.handleServiceError(identity, this.workerId, externalTask.id, error.message, '');
+    }
+  }
+
+  private async extendLocks<TPayload>(identity: IIdentity, externalTask: DataModels.ExternalTask.ExternalTask<TPayload>): Promise<void> {
+    try {
+      await this.externalTaskService.extendLock(identity, this.workerId, externalTask.id, this.lockDuration);
+    } catch (error) {
+      // This can happen, if the lock-extension was performed after the task was already finished.
+      // Since this isn't really an error, a warning suffices here.
+      logger.warn(`An error occured while trying to extend the lock for ExternalTask ${externalTask.id}`, error.message, error.stack);
+    }
+  }
+
+  private async sleep(milliseconds: number): Promise<void> {
+    return new Promise<void>((resolve: Function): void => {
+      setTimeout((): void => { resolve(); }, milliseconds);
+    });
+  }
+
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1,2 +1,3 @@
 export * from './accessors/index';
 export * from './consumer_api_client';
+export * from './external_task_worker';


### PR DESCRIPTION
## Changes

1. Imports the ExternalTaskApiClients and Workers
    - Includes the typescript- and the .NET contracts.
2. Sending an ExternalTask's result or error is now handled by the worker, instead of the result types

## Issues

PR: #55
