### PR TITLE
✨ Add limit and offset to list queries 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,28 +24,17 @@ pipeline {
   }
 
   stages {
-    stage('Prepare') {
+    stage('Install dependencies') {
       steps {
         dir('typescript') {
           nodejs(configId: env.NPM_RC_FILE, nodeJSInstallationName: env.NODE_JS_VERSION) {
             sh('node --version')
             sh('npm install --ignore-scripts')
-
-            // does prepare the version, but not commit it
-            sh('node ./node_modules/.bin/ci_tools prepare-version --allow-dirty-workdir')
           }
         }
       }
     }
-    stage('Lint') {
-      steps {
-        dir('typescript') {
-          sh('node --version')
-          sh('npm run lint')
-        }
-      }
-    }
-    stage('Build') {
+    stage('Build Sources') {
       steps {
         dir('typescript') {
           sh('node --version')
@@ -54,40 +43,61 @@ pipeline {
       }
     }
     stage('Test') {
-      steps {
-        dir('typescript') {
-          sh('node --version')
-          sh('npm run test')
+      parallel {
+        stage('Lint sources') {
+          steps {
+            dir('typescript') {
+              sh('node --version')
+              sh('npm run lint')
+            }
+          }
         }
-      }
-    }
-    stage('Commit & tag version') {
-      when {
-        anyOf {
-          branch "master"
-          branch "beta"
-          branch "develop"
-        }
-      }
-      steps {
-        dir('typescript') {
-          withCredentials([
-            usernamePassword(credentialsId: 'process-engine-ci_github-token', passwordVariable: 'GH_TOKEN', usernameVariable: 'GH_USER')
-          ]) {
-            // does not change the version, but commit and tag it
-            sh('node ./node_modules/.bin/ci_tools commit-and-tag-version --only-on-primary-branches')
-
-            sh('node ./node_modules/.bin/ci_tools update-github-release --only-on-primary-branches --use-title-and-text-from-git-tag');
+        stage('Execute tests') {
+          steps {
+            dir('typescript') {
+              sh('node --version')
+              sh('npm run test')
+            }
           }
         }
       }
     }
-    stage('Publish') {
+    stage('Set package version') {
       steps {
         dir('typescript') {
-
-          nodejs(configId: env.NPM_RC_FILE, nodeJSInstallationName: env.NODE_JS_VERSION) {
-            sh('node ./node_modules/.bin/ci_tools publish-npm-package --create-tag-from-branch-name')
+          sh('node --version')
+          sh('node ./node_modules/.bin/ci_tools prepare-version --allow-dirty-workdir');
+        }
+      }
+    }
+    stage('Publish') {
+      parallel {
+        stage('npm') {
+          steps {
+            dir('typescript') {
+              nodejs(configId: env.NPM_RC_FILE, nodeJSInstallationName: env.NODE_JS_VERSION) {
+                sh('node ./node_modules/.bin/ci_tools publish-npm-package --create-tag-from-branch-name')
+              }
+            }
+          }
+        }
+        stage('GitHub') {
+          when {
+            anyOf {
+              branch "beta"
+              branch "develop"
+              branch "master"
+            }
+          }
+          steps {
+            dir('typescript') {
+              withCredentials([
+                usernamePassword(credentialsId: 'process-engine-ci_github-token', passwordVariable: 'GH_TOKEN', usernameVariable: 'GH_USER')
+              ]) {
+                sh('node ./node_modules/.bin/ci_tools commit-and-tag-version --only-on-primary-branches')
+                sh('node ./node_modules/.bin/ci_tools update-github-release --only-on-primary-branches --use-title-and-text-from-git-tag');
+              }
+            }
           }
         }
       }

--- a/dotnet/src/ConsumerApiClientService.cs
+++ b/dotnet/src/ConsumerApiClientService.cs
@@ -35,7 +35,7 @@
         {
             var endpoint = RestSettings.Paths.ProcessModels;
 
-            var result = await this.SendRequestAndExpectResult<ProcessModelList>(identity, HttpMethod.Get, endpoint, offset, limit);
+            var result = await this.SendRequestAndExpectResult<ProcessModelList>(identity, HttpMethod.Get, endpoint, null, offset, limit);
 
             return result;
         }
@@ -151,7 +151,7 @@
         {
             var endpoint = RestSettings.Paths.GetOwnProcessInstances;
 
-            var result = await this.SendRequestAndExpectResult<IEnumerable<ProcessInstance>>(identity, HttpMethod.Get, endpoint, offset, limit);
+            var result = await this.SendRequestAndExpectResult<IEnumerable<ProcessInstance>>(identity, HttpMethod.Get, endpoint, null, offset, limit);
 
             return result;
         }

--- a/dotnet/src/ConsumerApiClientService.cs
+++ b/dotnet/src/ConsumerApiClientService.cs
@@ -31,6 +31,15 @@
             this.httpClient.Dispose();
         }
 
+        public async Task<ProcessModelList> GetProcessModels(IIdentity identity, int offset = 0, int limit = 0)
+        {
+            var endpoint = RestSettings.Paths.ProcessModels;
+
+            var result = await this.SendRequestAndExpectResult<ProcessModelList>(identity, HttpMethod.Get, endpoint);
+
+            return result;
+        }
+
         public async Task<ProcessModel> GetProcessModelById(IIdentity identity, string processModelId)
         {
             var endpoint = RestSettings.Paths.ProcessModelById
@@ -49,24 +58,6 @@
             var parsedResult = await this.GetProcessModelFromUrl(identity, endpoint);
 
             return parsedResult;
-        }
-
-        public async Task<ProcessModelList> GetProcessModels(IIdentity identity)
-        {
-            var endpoint = RestSettings.Paths.ProcessModels;
-
-            var result = await this.SendRequestAndExpectResult<ProcessModelList>(identity, HttpMethod.Get, endpoint);
-
-            return result;
-        }
-
-        public async Task<IEnumerable<ProcessInstance>> GetProcessInstancesByIdentity(IIdentity identity)
-        {
-            var endpoint = RestSettings.Paths.GetOwnProcessInstances;
-
-            var result = await this.SendRequestAndExpectResult<IEnumerable<ProcessInstance>>(identity, HttpMethod.Get, endpoint);
-
-            return result;
         }
 
         public async Task<ProcessStartResponsePayload> StartProcessInstance<TInputValues>(
@@ -155,7 +146,17 @@
 
             return parsedResult;
         }
-        public async Task<EventList> GetEventsForProcessModel(IIdentity identity, string processModelId)
+
+        public async Task<IEnumerable<ProcessInstance>> GetProcessInstancesByIdentity(IIdentity identity, int offset = 0, int limit = 0)
+        {
+            var endpoint = RestSettings.Paths.GetOwnProcessInstances;
+
+            var result = await this.SendRequestAndExpectResult<IEnumerable<ProcessInstance>>(identity, HttpMethod.Get, endpoint);
+
+            return result;
+        }
+
+        public async Task<EventList> GetEventsForProcessModel(IIdentity identity, string processModelId, int offset = 0, int limit = 0)
         {
             var endpoint = RestSettings.Paths.ProcessModelEvents
                 .Replace(RestSettings.Params.ProcessModelId, processModelId);
@@ -165,7 +166,7 @@
             return parsedResult;
         }
 
-        public async Task<EventList> GetEventsForCorrelation(IIdentity identity, string correlationId)
+        public async Task<EventList> GetEventsForCorrelation(IIdentity identity, string correlationId, int offset = 0, int limit = 0)
         {
             var endpoint = RestSettings.Paths.CorrelationEvents
                 .Replace(RestSettings.Params.CorrelationId, correlationId);
@@ -175,7 +176,7 @@
             return parsedResult;
         }
 
-        public async Task<EventList> GetEventsForProcessModelInCorrelation(IIdentity identity, string processModelId, string correlationId)
+        public async Task<EventList> GetEventsForProcessModelInCorrelation(IIdentity identity, string processModelId, string correlationId, int offset = 0, int limit = 0)
         {
             var endpoint = RestSettings.Paths.CorrelationEvents
                 .Replace(RestSettings.Params.ProcessModelId, processModelId)
@@ -232,7 +233,7 @@
             }
         }
 
-        public async Task<EmptyActivityList> GetEmptyActivitiesForProcessModel(IIdentity identity, string processModelId)
+        public async Task<EmptyActivityList> GetEmptyActivitiesForProcessModel(IIdentity identity, string processModelId, int offset = 0, int limit = 0)
         {
             var endpoint = RestSettings.Paths.ProcessModelEmptyActivities
                 .Replace(RestSettings.Params.ProcessModelId, processModelId);
@@ -242,7 +243,7 @@
             return parsedResult;
         }
 
-        public async Task<EmptyActivityList> GetEmptyActivitiesForProcessInstance(IIdentity identity, string processInstanceId)
+        public async Task<EmptyActivityList> GetEmptyActivitiesForProcessInstance(IIdentity identity, string processInstanceId, int offset = 0, int limit = 0)
         {
             var endpoint = RestSettings.Paths.ProcessInstanceEmptyActivities
                 .Replace(RestSettings.Params.ProcessInstanceId, processInstanceId);
@@ -252,7 +253,7 @@
             return parsedResult;
         }
 
-        public async Task<EmptyActivityList> GetEmptyActivitiesForCorrelation(IIdentity identity, string correlationId)
+        public async Task<EmptyActivityList> GetEmptyActivitiesForCorrelation(IIdentity identity, string correlationId, int offset = 0, int limit = 0)
         {
             var endpoint = RestSettings.Paths.CorrelationEmptyActivities
                 .Replace(RestSettings.Params.CorrelationId, correlationId);
@@ -262,7 +263,7 @@
             return parsedResult;
         }
 
-        public async Task<EmptyActivityList> GetEmptyActivitiesForProcessModelInCorrelation(IIdentity identity, string processModelId, string correlationId)
+        public async Task<EmptyActivityList> GetEmptyActivitiesForProcessModelInCorrelation(IIdentity identity, string processModelId, string correlationId, int offset = 0, int limit = 0)
         {
             var endpoint = RestSettings.Paths.ProcessModelCorrelationEmptyActivities
                 .Replace(RestSettings.Params.ProcessModelId, processModelId)
@@ -273,7 +274,7 @@
             return parsedResult;
         }
 
-        public async Task<EmptyActivityList> GetWaitingEmptyActivitiesByIdentity(IIdentity identity)
+        public async Task<EmptyActivityList> GetWaitingEmptyActivitiesByIdentity(IIdentity identity, int offset = 0, int limit = 0)
         {
             var endpoint = RestSettings.Paths.GetOwnEmptyActivities;
 
@@ -376,7 +377,7 @@
             await this.PostExternalTaskRequest<HandleServiceErrorRequest>(identity, endpoint, handleServiceErrorRequest);
         }
 
-        public async Task<UserTaskList> GetUserTasksForProcessModel(IIdentity identity, string processModelId)
+        public async Task<UserTaskList> GetUserTasksForProcessModel(IIdentity identity, string processModelId, int offset = 0, int limit = 0)
         {
             var endpoint = RestSettings.Paths.ProcessModelUserTasks
                 .Replace(RestSettings.Params.ProcessModelId, processModelId);
@@ -386,7 +387,7 @@
             return parsedResult;
         }
 
-        public async Task<UserTaskList> GetUserTasksForProcessInstance(IIdentity identity, string processInstanceId)
+        public async Task<UserTaskList> GetUserTasksForProcessInstance(IIdentity identity, string processInstanceId, int offset = 0, int limit = 0)
         {
             var endpoint = RestSettings.Paths.ProcessInstanceUserTasks
                 .Replace(RestSettings.Params.ProcessInstanceId, processInstanceId);
@@ -396,7 +397,7 @@
             return parsedResult;
         }
 
-        public async Task<UserTaskList> GetUserTasksForCorrelation(IIdentity identity, string correlationId)
+        public async Task<UserTaskList> GetUserTasksForCorrelation(IIdentity identity, string correlationId, int offset = 0, int limit = 0)
         {
             var endpoint = RestSettings.Paths.CorrelationUserTasks
                 .Replace(RestSettings.Params.CorrelationId, correlationId);
@@ -406,7 +407,7 @@
             return parsedResult;
         }
 
-        public async Task<UserTaskList> GetUserTasksForProcessModelInCorrelation(IIdentity identity, string processModelId, string correlationId)
+        public async Task<UserTaskList> GetUserTasksForProcessModelInCorrelation(IIdentity identity, string processModelId, string correlationId, int offset = 0, int limit = 0)
         {
             var endpoint = RestSettings.Paths.ProcessModelCorrelationUserTasks
                 .Replace(RestSettings.Params.ProcessModelId, processModelId)
@@ -417,7 +418,7 @@
             return parsedResult;
         }
 
-        public async Task<UserTaskList> GetWaitingUserTasksByIdentity(IIdentity identity)
+        public async Task<UserTaskList> GetWaitingUserTasksByIdentity(IIdentity identity, int offset = 0, int limit = 0)
         {
             var endpoint = RestSettings.Paths.GetOwnUserTasks;
 
@@ -446,7 +447,7 @@
             }
         }
 
-        public async Task<ManualTaskList> GetManualTasksForProcessModel(IIdentity identity, string processModelId)
+        public async Task<ManualTaskList> GetManualTasksForProcessModel(IIdentity identity, string processModelId, int offset = 0, int limit = 0)
         {
             var endpoint = RestSettings.Paths.ProcessModelManualTasks
                 .Replace(RestSettings.Params.ProcessModelId, processModelId);
@@ -456,7 +457,7 @@
             return parsedResult;
         }
 
-        public async Task<ManualTaskList> GetManualTasksForProcessInstance(IIdentity identity, string processInstanceId)
+        public async Task<ManualTaskList> GetManualTasksForProcessInstance(IIdentity identity, string processInstanceId, int offset = 0, int limit = 0)
         {
             var endpoint = RestSettings.Paths.ProcessInstanceManualTasks
                 .Replace(RestSettings.Params.ProcessInstanceId, processInstanceId);
@@ -466,7 +467,7 @@
             return parsedResult;
         }
 
-        public async Task<ManualTaskList> GetManualTasksForCorrelation(IIdentity identity, string correlationId)
+        public async Task<ManualTaskList> GetManualTasksForCorrelation(IIdentity identity, string correlationId, int offset = 0, int limit = 0)
         {
             var endpoint = RestSettings.Paths.CorrelationManualTasks
                 .Replace(RestSettings.Params.CorrelationId, correlationId);
@@ -476,7 +477,7 @@
             return parsedResult;
         }
 
-        public async Task<ManualTaskList> GetManualTasksForProcessModelInCorrelation(IIdentity identity, string processModelId, string correlationId)
+        public async Task<ManualTaskList> GetManualTasksForProcessModelInCorrelation(IIdentity identity, string processModelId, string correlationId, int offset = 0, int limit = 0)
         {
             var endpoint = RestSettings.Paths.ProcessModelCorrelationManualTasks
                 .Replace(RestSettings.Params.ProcessModelId, processModelId)
@@ -487,7 +488,7 @@
             return parsedResult;
         }
 
-        public async Task<ManualTaskList> GetWaitingManualTasksByIdentity(IIdentity identity)
+        public async Task<ManualTaskList> GetWaitingManualTasksByIdentity(IIdentity identity, int offset = 0, int limit = 0)
         {
             var endpoint = RestSettings.Paths.GetOwnManualTasks;
 

--- a/dotnet/src/ConsumerApiClientService.cs
+++ b/dotnet/src/ConsumerApiClientService.cs
@@ -35,7 +35,7 @@
         {
             var endpoint = RestSettings.Paths.ProcessModels;
 
-            var result = await this.SendRequestAndExpectResult<ProcessModelList>(identity, HttpMethod.Get, endpoint);
+            var result = await this.SendRequestAndExpectResult<ProcessModelList>(identity, HttpMethod.Get, endpoint, offset, limit);
 
             return result;
         }
@@ -151,7 +151,7 @@
         {
             var endpoint = RestSettings.Paths.GetOwnProcessInstances;
 
-            var result = await this.SendRequestAndExpectResult<IEnumerable<ProcessInstance>>(identity, HttpMethod.Get, endpoint);
+            var result = await this.SendRequestAndExpectResult<IEnumerable<ProcessInstance>>(identity, HttpMethod.Get, endpoint, offset, limit);
 
             return result;
         }
@@ -161,7 +161,7 @@
             var endpoint = RestSettings.Paths.ProcessModelEvents
                 .Replace(RestSettings.Params.ProcessModelId, processModelId);
 
-            var parsedResult = await this.GetTriggerableEventsFromUrl(identity, endpoint);
+            var parsedResult = await this.GetTriggerableEventsFromUrl(identity, endpoint, offset, limit);
 
             return parsedResult;
         }
@@ -171,7 +171,7 @@
             var endpoint = RestSettings.Paths.CorrelationEvents
                 .Replace(RestSettings.Params.CorrelationId, correlationId);
 
-            var parsedResult = await this.GetTriggerableEventsFromUrl(identity, endpoint);
+            var parsedResult = await this.GetTriggerableEventsFromUrl(identity, endpoint, offset, limit);
 
             return parsedResult;
         }
@@ -182,7 +182,7 @@
                 .Replace(RestSettings.Params.ProcessModelId, processModelId)
                 .Replace(RestSettings.Params.CorrelationId, correlationId);
 
-            var parsedResult = await this.GetTriggerableEventsFromUrl(identity, endpoint);
+            var parsedResult = await this.GetTriggerableEventsFromUrl(identity, endpoint, offset, limit);
 
             return parsedResult;
         }
@@ -238,7 +238,7 @@
             var endpoint = RestSettings.Paths.ProcessModelEmptyActivities
                 .Replace(RestSettings.Params.ProcessModelId, processModelId);
 
-            var parsedResult = await this.GetEmptyActivitiesFromUrl(identity, endpoint);
+            var parsedResult = await this.GetEmptyActivitiesFromUrl(identity, endpoint, offset, limit);
 
             return parsedResult;
         }
@@ -248,7 +248,7 @@
             var endpoint = RestSettings.Paths.ProcessInstanceEmptyActivities
                 .Replace(RestSettings.Params.ProcessInstanceId, processInstanceId);
 
-            var parsedResult = await this.GetEmptyActivitiesFromUrl(identity, endpoint);
+            var parsedResult = await this.GetEmptyActivitiesFromUrl(identity, endpoint, offset, limit);
 
             return parsedResult;
         }
@@ -258,7 +258,7 @@
             var endpoint = RestSettings.Paths.CorrelationEmptyActivities
                 .Replace(RestSettings.Params.CorrelationId, correlationId);
 
-            var parsedResult = await this.GetEmptyActivitiesFromUrl(identity, endpoint);
+            var parsedResult = await this.GetEmptyActivitiesFromUrl(identity, endpoint, offset, limit);
 
             return parsedResult;
         }
@@ -269,7 +269,7 @@
                 .Replace(RestSettings.Params.ProcessModelId, processModelId)
                 .Replace(RestSettings.Params.CorrelationId, correlationId);
 
-            var parsedResult = await this.GetEmptyActivitiesFromUrl(identity, endpoint);
+            var parsedResult = await this.GetEmptyActivitiesFromUrl(identity, endpoint, offset, limit);
 
             return parsedResult;
         }
@@ -278,7 +278,7 @@
         {
             var endpoint = RestSettings.Paths.GetOwnEmptyActivities;
 
-            var parsedResult = await this.GetEmptyActivitiesFromUrl(identity, endpoint);
+            var parsedResult = await this.GetEmptyActivitiesFromUrl(identity, endpoint, offset, limit);
 
             return parsedResult;
         }
@@ -382,7 +382,7 @@
             var endpoint = RestSettings.Paths.ProcessModelUserTasks
                 .Replace(RestSettings.Params.ProcessModelId, processModelId);
 
-            var parsedResult = await this.GetUserTasksFromUrl(identity, endpoint);
+            var parsedResult = await this.GetUserTasksFromUrl(identity, endpoint, offset, limit);
 
             return parsedResult;
         }
@@ -392,7 +392,7 @@
             var endpoint = RestSettings.Paths.ProcessInstanceUserTasks
                 .Replace(RestSettings.Params.ProcessInstanceId, processInstanceId);
 
-            var parsedResult = await this.GetUserTasksFromUrl(identity, endpoint);
+            var parsedResult = await this.GetUserTasksFromUrl(identity, endpoint, offset, limit);
 
             return parsedResult;
         }
@@ -402,7 +402,7 @@
             var endpoint = RestSettings.Paths.CorrelationUserTasks
                 .Replace(RestSettings.Params.CorrelationId, correlationId);
 
-            var parsedResult = await this.GetUserTasksFromUrl(identity, endpoint);
+            var parsedResult = await this.GetUserTasksFromUrl(identity, endpoint, offset, limit);
 
             return parsedResult;
         }
@@ -413,7 +413,7 @@
                 .Replace(RestSettings.Params.ProcessModelId, processModelId)
                 .Replace(RestSettings.Params.CorrelationId, correlationId);
 
-            var parsedResult = await this.GetUserTasksFromUrl(identity, endpoint);
+            var parsedResult = await this.GetUserTasksFromUrl(identity, endpoint, offset, limit);
 
             return parsedResult;
         }
@@ -422,7 +422,7 @@
         {
             var endpoint = RestSettings.Paths.GetOwnUserTasks;
 
-            var parsedResult = await this.GetUserTasksFromUrl(identity, endpoint);
+            var parsedResult = await this.GetUserTasksFromUrl(identity, endpoint, offset, limit);
 
             return parsedResult;
         }
@@ -452,7 +452,7 @@
             var endpoint = RestSettings.Paths.ProcessModelManualTasks
                 .Replace(RestSettings.Params.ProcessModelId, processModelId);
 
-            var parsedResult = await this.GetManualTasksFromUrl(identity, endpoint);
+            var parsedResult = await this.GetManualTasksFromUrl(identity, endpoint, offset, limit);
 
             return parsedResult;
         }
@@ -462,7 +462,7 @@
             var endpoint = RestSettings.Paths.ProcessInstanceManualTasks
                 .Replace(RestSettings.Params.ProcessInstanceId, processInstanceId);
 
-            var parsedResult = await this.GetManualTasksFromUrl(identity, endpoint);
+            var parsedResult = await this.GetManualTasksFromUrl(identity, endpoint, offset, limit);
 
             return parsedResult;
         }
@@ -472,7 +472,7 @@
             var endpoint = RestSettings.Paths.CorrelationManualTasks
                 .Replace(RestSettings.Params.CorrelationId, correlationId);
 
-            var parsedResult = await this.GetManualTasksFromUrl(identity, endpoint);
+            var parsedResult = await this.GetManualTasksFromUrl(identity, endpoint, offset, limit);
 
             return parsedResult;
         }
@@ -483,7 +483,7 @@
                 .Replace(RestSettings.Params.ProcessModelId, processModelId)
                 .Replace(RestSettings.Params.CorrelationId, correlationId);
 
-            var parsedResult = await this.GetManualTasksFromUrl(identity, endpoint);
+            var parsedResult = await this.GetManualTasksFromUrl(identity, endpoint, offset, limit);
 
             return parsedResult;
         }
@@ -492,7 +492,7 @@
         {
             var endpoint = RestSettings.Paths.GetOwnManualTasks;
 
-            var parsedResult = await this.GetManualTasksFromUrl(identity, endpoint);
+            var parsedResult = await this.GetManualTasksFromUrl(identity, endpoint, offset, limit);
 
             return parsedResult;
         }
@@ -522,14 +522,14 @@
             return result;
         }
 
-        private async Task<EventList> GetTriggerableEventsFromUrl(IIdentity identity, string url)
+        private async Task<EventList> GetTriggerableEventsFromUrl(IIdentity identity, string url, int offset = 0, int limit = 0)
         {
             var result = await this.SendRequestAndExpectResult<EventList>(identity, HttpMethod.Get, url);
 
             return result;
         }
 
-        private async Task<EmptyActivityList> GetEmptyActivitiesFromUrl(IIdentity identity, string url)
+        private async Task<EmptyActivityList> GetEmptyActivitiesFromUrl(IIdentity identity, string url, int offset = 0, int limit = 0)
         {
             var result = await this.SendRequestAndExpectResult<EmptyActivityList>(identity, HttpMethod.Get, url);
 
@@ -553,23 +553,31 @@
             }
         }
 
-        private async Task<ManualTaskList> GetManualTasksFromUrl(IIdentity identity, string url)
+        private async Task<ManualTaskList> GetManualTasksFromUrl(IIdentity identity, string url, int offset = 0, int limit = 0)
         {
             var result = await this.SendRequestAndExpectResult<ManualTaskList>(identity, HttpMethod.Get, url);
 
             return result;
         }
 
-        private async Task<UserTaskList> GetUserTasksFromUrl(IIdentity identity, string url)
+        private async Task<UserTaskList> GetUserTasksFromUrl(IIdentity identity, string url, int offset = 0, int limit = 0)
         {
             var result = await this.SendRequestAndExpectResult<UserTaskList>(identity, HttpMethod.Get, url);
 
             return result;
         }
 
-        private async Task<TResult> SendRequestAndExpectResult<TResult>(IIdentity identity, HttpMethod method, string endpoint, HttpContent content = null)
+        private async Task<TResult> SendRequestAndExpectResult<TResult>(IIdentity identity, HttpMethod method, string endpoint, HttpContent content = null, int offset = 0, int limit = 0)
         {
             var url = this.ApplyBaseUrl(endpoint);
+
+            if(url.Contains("?")) {
+                url = $"{url}&offset={offset}&limit={limit}";
+            }
+            else
+            {
+                url = $"{url}?offset={offset}&limit={limit}";
+            }
 
             TResult parsedResult = default(TResult);
 
@@ -592,18 +600,6 @@
         private string ApplyBaseUrl(string endpoint)
         {
             return $"{RestSettings.Endpoints.ConsumerAPI}{endpoint}";
-        }
-
-        private StringContent SerializeRequest<TRequest>(TRequest request)
-        {
-            var settings = new JsonSerializerSettings
-            {
-                ContractResolver = new CamelCasePropertyNamesContractResolver()
-            };
-
-            var serializedRequest = JsonConvert.SerializeObject(request, settings);
-            var content = new StringContent(serializedRequest, Encoding.UTF8, "application/json");
-            return content;
         }
 
         private HttpRequestMessage CreateRequestMessage(IIdentity identity, HttpMethod method, string url, HttpContent content = null)

--- a/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
+++ b/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <RootNamespace>ProcessEngine.ConsumerAPI.Client</RootNamespace>
     <AssemblyName>ProcessEngine.ConsumerAPI.Client</AssemblyName>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
+++ b/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.1.0-feature-add-limit-and-offset-to-list-queries" />
+    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.1.0-develop" />
     <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
   </ItemGroup>
 

--- a/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
+++ b/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.0.0-develop" />
+    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.1.0-feature-add-limit-and-offset-to-list-queries" />
     <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
   </ItemGroup>
 

--- a/dotnet/tests/ProcessEngine.ConsumerAPI.Client.Tests.csproj
+++ b/dotnet/tests/ProcessEngine.ConsumerAPI.Client.Tests.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.0.0-develop" />
+    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.1.0-feature-add-limit-and-offset-to-list-queries" />
     <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="xunit" Version="2.4.0" />

--- a/dotnet/tests/ProcessEngine.ConsumerAPI.Client.Tests.csproj
+++ b/dotnet/tests/ProcessEngine.ConsumerAPI.Client.Tests.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.1.0-feature-add-limit-and-offset-to-list-queries" />
+    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.1.0-develop" />
     <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="xunit" Version="2.4.0" />

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -31,7 +31,7 @@
     "@essential-projects/errors_ts": "^1.5.0",
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/consumer_api_contracts": "feature~add_limit_and_offset_to_list_queries",
+    "@process-engine/consumer_api_contracts": "8.1.0-35fc9279-b29",
     "async-middleware": "^1.2.1",
     "bluebird": "^3.5.3",
     "loggerhythm": "^3.0.3",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",
-    "@process-engine/ci_tools": "2.0.0-alpha.51",
+    "@process-engine/ci_tools": "^2.0.0",
     "@types/express": "^4.16.0",
     "@types/node": "^10.12.2",
     "@types/socket.io": "^2.1.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -31,7 +31,7 @@
     "@essential-projects/errors_ts": "^1.5.0",
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/consumer_api_contracts": "8.1.0-eb122423-b28",
+    "@process-engine/consumer_api_contracts": "feature~add_limit_and_offset_to_list_queries",
     "async-middleware": "^1.2.1",
     "bluebird": "^3.5.3",
     "loggerhythm": "^3.0.3",

--- a/typescript/src/accessors/external_accessor.ts
+++ b/typescript/src/accessors/external_accessor.ts
@@ -388,7 +388,7 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
       url = `${url}&end_event_id=${endEventId}`;
     }
 
-    url = this.buildUrl(urlRestPart);
+    url = this.buildUrl(url);
 
     return url;
   }

--- a/typescript/src/accessors/external_accessor.ts
+++ b/typescript/src/accessors/external_accessor.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import * as uuid from 'node-uuid';
 import * as io from 'socket.io-client';
 
@@ -297,10 +298,14 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
   }
 
   // Process models and instances
-  public async getProcessModels(identity: IIdentity): Promise<DataModels.ProcessModels.ProcessModelList> {
+  public async getProcessModels(
+    identity: IIdentity,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.ProcessModels.ProcessModelList> {
     const requestAuthHeaders = this.createRequestAuthHeaders(identity);
 
-    const url = this.applyBaseUrl(restSettings.paths.processModels);
+    const url = this.buildUrl(restSettings.paths.processModels, offset, limit);
 
     const httpResponse = await this.httpClient.get<DataModels.ProcessModels.ProcessModelList>(url, requestAuthHeaders);
 
@@ -310,8 +315,10 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
   public async getProcessModelById(identity: IIdentity, processModelId: string): Promise<DataModels.ProcessModels.ProcessModel> {
     const requestAuthHeaders = this.createRequestAuthHeaders(identity);
 
-    let url = restSettings.paths.processModelById.replace(restSettings.params.processModelId, processModelId);
-    url = this.applyBaseUrl(url);
+    const urlRestPart = restSettings.paths.processModelById
+      .replace(restSettings.params.processModelId, processModelId);
+
+    const url = this.buildUrl(urlRestPart);
 
     const httpResponse = await this.httpClient.get<DataModels.ProcessModels.ProcessModel>(url, requestAuthHeaders);
 
@@ -321,8 +328,10 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
   public async getProcessModelByProcessInstanceId(identity: IIdentity, processInstanceId: string): Promise<DataModels.ProcessModels.ProcessModel> {
     const requestAuthHeaders = this.createRequestAuthHeaders(identity);
 
-    let url = restSettings.paths.processModelByProcessInstanceId.replace(restSettings.params.processInstanceId, processInstanceId);
-    url = this.applyBaseUrl(url);
+    const urlRestPart = restSettings.paths.processModelByProcessInstanceId
+      .replace(restSettings.params.processInstanceId, processInstanceId);
+
+    const url = this.buildUrl(urlRestPart);
 
     const httpResponse = await this.httpClient.get<DataModels.ProcessModels.ProcessModel>(url, requestAuthHeaders);
 
@@ -363,10 +372,11 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     endEventId: string,
     startEventId?: string,
   ): string {
-    let url = restSettings.paths.startProcessInstance
+
+    const urlRestPart = restSettings.paths.startProcessInstance
       .replace(restSettings.params.processModelId, processModelId);
 
-    url = `${url}?start_callback_type=${startCallbackType}`;
+    let url = `${urlRestPart}?start_callback_type=${startCallbackType}`;
 
     const startEventIdIsGiven = startEventId !== undefined;
     if (startEventIdIsGiven) {
@@ -378,7 +388,7 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
       url = `${url}&end_event_id=${endEventId}`;
     }
 
-    url = this.applyBaseUrl(url);
+    url = this.buildUrl(urlRestPart);
 
     return url;
   }
@@ -388,11 +398,12 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     correlationId: string,
     processModelId: string,
   ): Promise<Array<DataModels.CorrelationResult>> {
-    let url = restSettings.paths.getProcessResultForCorrelation
+
+    const urlRestPart = restSettings.paths.getProcessResultForCorrelation
       .replace(restSettings.params.correlationId, correlationId)
       .replace(restSettings.params.processModelId, processModelId);
 
-    url = this.applyBaseUrl(url);
+    const url = this.buildUrl(urlRestPart);
 
     const requestAuthHeaders = this.createRequestAuthHeaders(identity);
 
@@ -401,88 +412,33 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     return httpResponse.result;
   }
 
-  public async getProcessInstancesByIdentity(identity: IIdentity): Promise<Array<DataModels.ProcessInstance>> {
+  public async getProcessInstancesByIdentity(
+    identity: IIdentity,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<Array<DataModels.ProcessInstance>> {
     const requestAuthHeaders = this.createRequestAuthHeaders(identity);
 
-    let url = restSettings.paths.getOwnProcessInstances;
-    url = this.applyBaseUrl(url);
+    const url = this.buildUrl(restSettings.paths.getOwnProcessInstances, offset, limit);
 
     const httpResponse = await this.httpClient.get<Array<DataModels.ProcessInstance>>(url, requestAuthHeaders);
 
     return httpResponse.result;
   }
 
-  // Events
-  public async getEventsForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.Events.EventList> {
-    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
-
-    let url = restSettings.paths.processModelEvents.replace(restSettings.params.processModelId, processModelId);
-    url = this.applyBaseUrl(url);
-
-    const httpResponse = await this.httpClient.get<DataModels.Events.EventList>(url, requestAuthHeaders);
-
-    return httpResponse.result;
-  }
-
-  public async getEventsForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.Events.EventList> {
-    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
-
-    let url = restSettings.paths.correlationEvents.replace(restSettings.params.correlationId, correlationId);
-    url = this.applyBaseUrl(url);
-
-    const httpResponse = await this.httpClient.get<DataModels.Events.EventList>(url, requestAuthHeaders);
-
-    return httpResponse.result;
-  }
-
-  public async getEventsForProcessModelInCorrelation(
+  // Empty Activities
+  public async getEmptyActivitiesForProcessModel(
     identity: IIdentity,
     processModelId: string,
-    correlationId: string,
-  ): Promise<DataModels.Events.EventList> {
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.EmptyActivities.EmptyActivityList> {
     const requestAuthHeaders = this.createRequestAuthHeaders(identity);
 
-    let url = restSettings.paths.processModelCorrelationEvents
-      .replace(restSettings.params.processModelId, processModelId)
-      .replace(restSettings.params.correlationId, correlationId);
-
-    url = this.applyBaseUrl(url);
-
-    const httpResponse = await this.httpClient.get<DataModels.Events.EventList>(url, requestAuthHeaders);
-
-    return httpResponse.result;
-  }
-
-  public async triggerMessageEvent(identity: IIdentity, messageName: string, payload?: DataModels.Events.EventTriggerPayload): Promise<void> {
-    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
-
-    let url = restSettings.paths.triggerMessageEvent
-      .replace(restSettings.params.eventName, messageName);
-
-    url = this.applyBaseUrl(url);
-
-    await this.httpClient.post<DataModels.Events.EventTriggerPayload, void>(url, payload, requestAuthHeaders);
-  }
-
-  public async triggerSignalEvent(identity: IIdentity, signalName: string, payload?: DataModels.Events.EventTriggerPayload): Promise<void> {
-    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
-
-    let url = restSettings.paths.triggerSignalEvent
-      .replace(restSettings.params.eventName, signalName);
-
-    url = this.applyBaseUrl(url);
-
-    await this.httpClient.post<DataModels.Events.EventTriggerPayload, void>(url, payload, requestAuthHeaders);
-  }
-
-  // Empty Activities
-  public async getEmptyActivitiesForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.EmptyActivities.EmptyActivityList> {
-    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
-
-    const restPath = restSettings.paths.processModelEmptyActivities
+    const urlRestPart = restSettings.paths.processModelEmptyActivities
       .replace(restSettings.params.processModelId, processModelId);
 
-    const url = this.applyBaseUrl(restPath);
+    const url = this.buildUrl(urlRestPart, offset, limit);
 
     const httpResponse = await this.httpClient.get<DataModels.EmptyActivities.EmptyActivityList>(url, requestAuthHeaders);
 
@@ -492,26 +448,33 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
   public async getEmptyActivitiesForProcessInstance(
     identity: IIdentity,
     processInstanceId: string,
+    offset: number = 0,
+    limit: number = 0,
   ): Promise<DataModels.EmptyActivities.EmptyActivityList> {
     const requestAuthHeaders = this.createRequestAuthHeaders(identity);
 
-    const restPath = restSettings.paths.processInstanceEmptyActivities
+    const urlRestPart = restSettings.paths.processInstanceEmptyActivities
       .replace(restSettings.params.processInstanceId, processInstanceId);
 
-    const url = this.applyBaseUrl(restPath);
+    const url = this.buildUrl(urlRestPart, offset, limit);
 
     const httpResponse = await this.httpClient.get<DataModels.EmptyActivities.EmptyActivityList>(url, requestAuthHeaders);
 
     return httpResponse.result;
   }
 
-  public async getEmptyActivitiesForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.EmptyActivities.EmptyActivityList> {
+  public async getEmptyActivitiesForCorrelation(
+    identity: IIdentity,
+    correlationId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.EmptyActivities.EmptyActivityList> {
     const requestAuthHeaders = this.createRequestAuthHeaders(identity);
 
-    const restPath = restSettings.paths.correlationEmptyActivities
+    const urlRestPart = restSettings.paths.correlationEmptyActivities
       .replace(restSettings.params.correlationId, correlationId);
 
-    const url = this.applyBaseUrl(restPath);
+    const url = this.buildUrl(urlRestPart, offset, limit);
 
     const httpResponse = await this.httpClient.get<DataModels.EmptyActivities.EmptyActivityList>(url, requestAuthHeaders);
 
@@ -522,24 +485,30 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     identity: IIdentity,
     processModelId: string,
     correlationId: string,
+    offset: number = 0,
+    limit: number = 0,
   ): Promise<DataModels.EmptyActivities.EmptyActivityList> {
     const requestAuthHeaders = this.createRequestAuthHeaders(identity);
 
-    const restPath = restSettings.paths.processModelCorrelationEmptyActivities
+    const urlRestPart = restSettings.paths.processModelCorrelationEmptyActivities
       .replace(restSettings.params.processModelId, processModelId)
       .replace(restSettings.params.correlationId, correlationId);
 
-    const url = this.applyBaseUrl(restPath);
+    const url = this.buildUrl(urlRestPart, offset, limit);
 
     const httpResponse = await this.httpClient.get<DataModels.EmptyActivities.EmptyActivityList>(url, requestAuthHeaders);
 
     return httpResponse.result;
   }
 
-  public async getWaitingEmptyActivitiesByIdentity(identity: IIdentity): Promise<DataModels.EmptyActivities.EmptyActivityList> {
+  public async getWaitingEmptyActivitiesByIdentity(
+    identity: IIdentity,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.EmptyActivities.EmptyActivityList> {
     const requestAuthHeaders = this.createRequestAuthHeaders(identity);
 
-    const url = this.applyBaseUrl(restSettings.paths.getOwnEmptyActivities);
+    const url = this.buildUrl(restSettings.paths.getOwnEmptyActivities, offset, limit);
 
     const httpResponse = await this.httpClient.get<DataModels.EmptyActivities.EmptyActivityList>(url, requestAuthHeaders);
 
@@ -554,15 +523,94 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
   ): Promise<void> {
     const requestAuthHeaders = this.createRequestAuthHeaders(identity);
 
-    let url = restSettings.paths.finishEmptyActivity
+    const urlRestPart = restSettings.paths.finishEmptyActivity
       .replace(restSettings.params.processInstanceId, processInstanceId)
       .replace(restSettings.params.correlationId, correlationId)
       .replace(restSettings.params.emptyActivityInstanceId, emptyActivityInstanceId);
 
-    url = this.applyBaseUrl(url);
+    const url = this.buildUrl(urlRestPart);
 
     const body: {} = {};
     await this.httpClient.post(url, body, requestAuthHeaders);
+  }
+
+  // Events
+  public async getEventsForProcessModel(
+    identity: IIdentity,
+    processModelId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.Events.EventList> {
+    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
+
+    const urlRestPart = restSettings.paths.processModelEvents
+      .replace(restSettings.params.processModelId, processModelId);
+
+    const url = this.buildUrl(urlRestPart, offset, limit);
+
+    const httpResponse = await this.httpClient.get<DataModels.Events.EventList>(url, requestAuthHeaders);
+
+    return httpResponse.result;
+  }
+
+  public async getEventsForCorrelation(
+    identity: IIdentity,
+    correlationId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.Events.EventList> {
+    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
+
+    const urlRestPart = restSettings.paths.correlationEvents
+      .replace(restSettings.params.correlationId, correlationId);
+
+    const url = this.buildUrl(urlRestPart, offset, limit);
+
+    const httpResponse = await this.httpClient.get<DataModels.Events.EventList>(url, requestAuthHeaders);
+
+    return httpResponse.result;
+  }
+
+  public async getEventsForProcessModelInCorrelation(
+    identity: IIdentity,
+    processModelId: string,
+    correlationId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.Events.EventList> {
+    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
+
+    const urlRestPart = restSettings.paths.processModelCorrelationEvents
+      .replace(restSettings.params.processModelId, processModelId)
+      .replace(restSettings.params.correlationId, correlationId);
+
+    const url = this.buildUrl(urlRestPart, offset, limit);
+
+    const httpResponse = await this.httpClient.get<DataModels.Events.EventList>(url, requestAuthHeaders);
+
+    return httpResponse.result;
+  }
+
+  public async triggerMessageEvent(identity: IIdentity, messageName: string, payload?: DataModels.Events.EventTriggerPayload): Promise<void> {
+    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
+
+    const urlRestPart = restSettings.paths.triggerMessageEvent
+      .replace(restSettings.params.eventName, messageName);
+
+    const url = this.buildUrl(urlRestPart);
+
+    await this.httpClient.post<DataModels.Events.EventTriggerPayload, void>(url, payload, requestAuthHeaders);
+  }
+
+  public async triggerSignalEvent(identity: IIdentity, signalName: string, payload?: DataModels.Events.EventTriggerPayload): Promise<void> {
+    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
+
+    const urlRestPart = restSettings.paths.triggerSignalEvent
+      .replace(restSettings.params.eventName, signalName);
+
+    const url = this.buildUrl(urlRestPart);
+
+    await this.httpClient.post<DataModels.Events.EventTriggerPayload, void>(url, payload, requestAuthHeaders);
   }
 
   // ExternalTasks
@@ -577,8 +625,8 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
 
     const requestAuthHeaders = this.createRequestAuthHeaders(identity);
 
-    let url = restSettings.paths.fetchAndLockExternalTasks;
-    url = this.applyBaseUrl(url);
+    const urlRestPart = restSettings.paths.fetchAndLockExternalTasks;
+    const url = this.buildUrl(urlRestPart);
 
     const payload = new DataModels.ExternalTask.FetchAndLockRequestPayload(workerId, topicName, maxTasks, longPollingTimeout, lockDuration);
 
@@ -594,10 +642,10 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
 
     const requestAuthHeaders = this.createRequestAuthHeaders(identity);
 
-    let url = restSettings.paths.extendExternalTaskLock
+    const urlRestPart = restSettings.paths.extendExternalTaskLock
       .replace(restSettings.params.externalTaskId, externalTaskId);
 
-    url = this.applyBaseUrl(url);
+    const url = this.buildUrl(urlRestPart);
 
     const payload = new DataModels.ExternalTask.ExtendLockRequestPayload(workerId, additionalDuration);
 
@@ -608,10 +656,10 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
 
     const requestAuthHeaders = this.createRequestAuthHeaders(identity);
 
-    let url = restSettings.paths.finishExternalTaskWithBpmnError
+    const urlRestPart = restSettings.paths.finishExternalTaskWithBpmnError
       .replace(restSettings.params.externalTaskId, externalTaskId);
 
-    url = this.applyBaseUrl(url);
+    const url = this.buildUrl(urlRestPart);
 
     const payload = new DataModels.ExternalTask.HandleBpmnErrorRequestPayload(workerId, errorCode);
 
@@ -628,10 +676,10 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
 
     const requestAuthHeaders = this.createRequestAuthHeaders(identity);
 
-    let url = restSettings.paths.finishExternalTaskWithServiceError
+    const urlRestPart = restSettings.paths.finishExternalTaskWithServiceError
       .replace(restSettings.params.externalTaskId, externalTaskId);
 
-    url = this.applyBaseUrl(url);
+    const url = this.buildUrl(urlRestPart);
 
     const payload = new DataModels.ExternalTask.HandleServiceErrorRequestPayload(workerId, errorMessage, errorDetails);
 
@@ -642,135 +690,65 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
 
     const requestAuthHeaders = this.createRequestAuthHeaders(identity);
 
-    let url = restSettings.paths.finishExternalTask
+    const urlRestPart = restSettings.paths.finishExternalTask
       .replace(restSettings.params.externalTaskId, externalTaskId);
 
-    url = this.applyBaseUrl(url);
+    const url = this.buildUrl(urlRestPart);
 
     const payload = new DataModels.ExternalTask.FinishExternalTaskRequestPayload(workerId, results);
 
     await this.httpClient.post<DataModels.ExternalTask.FinishExternalTaskRequestPayload<TResultType>, void>(url, payload, requestAuthHeaders);
   }
 
-  // UserTasks
-  public async getUserTasksForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.UserTasks.UserTaskList> {
-    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
-
-    let url = restSettings.paths.processModelUserTasks.replace(restSettings.params.processModelId, processModelId);
-    url = this.applyBaseUrl(url);
-
-    const httpResponse = await this.httpClient.get<DataModels.UserTasks.UserTaskList>(url, requestAuthHeaders);
-
-    return httpResponse.result;
-  }
-
-  public async getUserTasksForProcessInstance(identity: IIdentity, processInstanceId: string): Promise<DataModels.UserTasks.UserTaskList> {
-    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
-
-    let url = restSettings.paths.processInstanceUserTasks.replace(restSettings.params.processInstanceId, processInstanceId);
-    url = this.applyBaseUrl(url);
-
-    const httpResponse = await this.httpClient.get<DataModels.UserTasks.UserTaskList>(url, requestAuthHeaders);
-
-    return httpResponse.result;
-  }
-
-  public async getUserTasksForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.UserTasks.UserTaskList> {
-    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
-
-    let url = restSettings.paths.correlationUserTasks.replace(restSettings.params.correlationId, correlationId);
-    url = this.applyBaseUrl(url);
-
-    const httpResponse = await this.httpClient.get<DataModels.UserTasks.UserTaskList>(url, requestAuthHeaders);
-
-    return httpResponse.result;
-  }
-
-  public async getUserTasksForProcessModelInCorrelation(
+  // ManualTasks
+  public async getManualTasksForProcessModel(
     identity: IIdentity,
     processModelId: string,
-    correlationId: string,
-  ): Promise<DataModels.UserTasks.UserTaskList> {
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.ManualTasks.ManualTaskList> {
     const requestAuthHeaders = this.createRequestAuthHeaders(identity);
 
-    let url = restSettings.paths.processModelCorrelationUserTasks
-      .replace(restSettings.params.processModelId, processModelId)
-      .replace(restSettings.params.correlationId, correlationId);
-
-    url = this.applyBaseUrl(url);
-
-    const httpResponse = await this.httpClient.get<DataModels.UserTasks.UserTaskList>(url, requestAuthHeaders);
-
-    return httpResponse.result;
-  }
-
-  public async getWaitingUserTasksByIdentity(identity: IIdentity): Promise<DataModels.UserTasks.UserTaskList> {
-    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
-
-    const urlRestPart = restSettings.paths.getOwnUserTasks;
-    const url = this.applyBaseUrl(urlRestPart);
-
-    const httpResponse = await this.httpClient.get<DataModels.UserTasks.UserTaskList>(url, requestAuthHeaders);
-
-    return httpResponse.result;
-  }
-
-  public async finishUserTask(
-    identity: IIdentity,
-    processInstanceId: string,
-    correlationId: string,
-    userTaskInstanceId: string,
-    userTaskResult: DataModels.UserTasks.UserTaskResult,
-  ): Promise<void> {
-    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
-
-    let url = restSettings.paths.finishUserTask
-      .replace(restSettings.params.processInstanceId, processInstanceId)
-      .replace(restSettings.params.correlationId, correlationId)
-      .replace(restSettings.params.userTaskInstanceId, userTaskInstanceId);
-
-    url = this.applyBaseUrl(url);
-
-    await this.httpClient.post<DataModels.UserTasks.UserTaskResult, void>(url, userTaskResult, requestAuthHeaders);
-  }
-
-  // ManualTasks
-  public async getManualTasksForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
-    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
-
-    const urlRestPart = restSettings.paths
-      .processModelManualTasks
+    const urlRestPart = restSettings.paths.processModelManualTasks
       .replace(restSettings.params.processModelId, processModelId);
 
-    const url = this.applyBaseUrl(urlRestPart);
+    const url = this.buildUrl(urlRestPart, offset, limit);
 
     const httpResponse = await this.httpClient.get<DataModels.ManualTasks.ManualTaskList>(url, requestAuthHeaders);
 
     return httpResponse.result;
   }
 
-  public async getManualTasksForProcessInstance(identity: IIdentity, processInstanceId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
+  public async getManualTasksForProcessInstance(
+    identity: IIdentity,
+    processInstanceId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.ManualTasks.ManualTaskList> {
     const requestAuthHeaders = this.createRequestAuthHeaders(identity);
 
-    const urlRestPart = restSettings.paths
-      .processInstanceManualTasks
+    const urlRestPart = restSettings.paths.processInstanceManualTasks
       .replace(restSettings.params.processInstanceId, processInstanceId);
 
-    const url = this.applyBaseUrl(urlRestPart);
+    const url = this.buildUrl(urlRestPart, offset, limit);
 
     const httpResponse = await this.httpClient.get<DataModels.ManualTasks.ManualTaskList>(url, requestAuthHeaders);
 
     return httpResponse.result;
   }
 
-  public async getManualTasksForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
+  public async getManualTasksForCorrelation(
+    identity: IIdentity,
+    correlationId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.ManualTasks.ManualTaskList> {
     const requestAuthHeaders = this.createRequestAuthHeaders(identity);
 
-    const urlRestPart = restSettings.paths
-      .correlationManualTasks
+    const urlRestPart = restSettings.paths.correlationManualTasks
       .replace(restSettings.params.correlationId, correlationId);
 
-    const url = this.applyBaseUrl(urlRestPart);
+    const url = this.buildUrl(urlRestPart, offset, limit);
 
     const httpResponse = await this.httpClient.get<DataModels.ManualTasks.ManualTaskList>(url, requestAuthHeaders);
 
@@ -781,6 +759,8 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     identity: IIdentity,
     processModelId: string,
     correlationId: string,
+    offset: number = 0,
+    limit: number = 0,
   ): Promise<DataModels.ManualTasks.ManualTaskList> {
     const requestAuthHeaders = this.createRequestAuthHeaders(identity);
 
@@ -788,18 +768,21 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
       .replace(restSettings.params.processModelId, processModelId)
       .replace(restSettings.params.correlationId, correlationId);
 
-    const url = this.applyBaseUrl(urlRestPart);
+    const url = this.buildUrl(urlRestPart, offset, limit);
 
     const httpResponse = await this.httpClient.get<DataModels.ManualTasks.ManualTaskList>(url, requestAuthHeaders);
 
     return httpResponse.result;
   }
 
-  public async getWaitingManualTasksByIdentity(identity: IIdentity): Promise<DataModels.ManualTasks.ManualTaskList> {
+  public async getWaitingManualTasksByIdentity(
+    identity: IIdentity,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.ManualTasks.ManualTaskList> {
     const requestAuthHeaders = this.createRequestAuthHeaders(identity);
 
-    const urlRestPart = restSettings.paths.getOwnManualTasks;
-    const url = this.applyBaseUrl(urlRestPart);
+    const url = this.buildUrl(restSettings.paths.getOwnManualTasks, offset, limit);
 
     const httpResponse = await this.httpClient.get<DataModels.ManualTasks.ManualTaskList>(url, requestAuthHeaders);
 
@@ -819,10 +802,118 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
       .replace(restSettings.params.correlationId, correlationId)
       .replace(restSettings.params.manualTaskInstanceId, manualTaskInstanceId);
 
-    const url = this.applyBaseUrl(urlRestPart);
+    const url = this.buildUrl(urlRestPart);
 
     const body: {} = {};
     await this.httpClient.post(url, body, requestAuthHeaders);
+  }
+
+  // UserTasks
+  public async getUserTasksForProcessModel(
+    identity: IIdentity,
+    processModelId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.UserTasks.UserTaskList> {
+    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
+
+    const urlRestPart = restSettings.paths.processModelUserTasks
+      .replace(restSettings.params.processModelId, processModelId);
+
+    const url = this.buildUrl(urlRestPart, offset, limit);
+
+    const httpResponse = await this.httpClient.get<DataModels.UserTasks.UserTaskList>(url, requestAuthHeaders);
+
+    return httpResponse.result;
+  }
+
+  public async getUserTasksForProcessInstance(
+    identity: IIdentity,
+    processInstanceId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.UserTasks.UserTaskList> {
+    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
+
+    const urlRestPart = restSettings.paths.processInstanceUserTasks
+      .replace(restSettings.params.processInstanceId, processInstanceId);
+
+    const url = this.buildUrl(urlRestPart, offset, limit);
+
+    const httpResponse = await this.httpClient.get<DataModels.UserTasks.UserTaskList>(url, requestAuthHeaders);
+
+    return httpResponse.result;
+  }
+
+  public async getUserTasksForCorrelation(
+    identity: IIdentity,
+    correlationId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.UserTasks.UserTaskList> {
+    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
+
+    const urlRestPart = restSettings.paths.correlationUserTasks
+      .replace(restSettings.params.correlationId, correlationId);
+
+    const url = this.buildUrl(urlRestPart, offset, limit);
+
+    const httpResponse = await this.httpClient.get<DataModels.UserTasks.UserTaskList>(url, requestAuthHeaders);
+
+    return httpResponse.result;
+  }
+
+  public async getUserTasksForProcessModelInCorrelation(
+    identity: IIdentity,
+    processModelId: string,
+    correlationId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.UserTasks.UserTaskList> {
+    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
+
+    const urlRestPart = restSettings.paths.processModelCorrelationUserTasks
+      .replace(restSettings.params.processModelId, processModelId)
+      .replace(restSettings.params.correlationId, correlationId);
+
+    const url = this.buildUrl(urlRestPart, offset, limit);
+
+    const httpResponse = await this.httpClient.get<DataModels.UserTasks.UserTaskList>(url, requestAuthHeaders);
+
+    return httpResponse.result;
+  }
+
+  public async getWaitingUserTasksByIdentity(
+    identity: IIdentity,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.UserTasks.UserTaskList> {
+    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
+
+    const url = this.buildUrl(restSettings.paths.getOwnUserTasks, offset, limit);
+
+    const httpResponse = await this.httpClient.get<DataModels.UserTasks.UserTaskList>(url, requestAuthHeaders);
+
+    return httpResponse.result;
+  }
+
+  public async finishUserTask(
+    identity: IIdentity,
+    processInstanceId: string,
+    correlationId: string,
+    userTaskInstanceId: string,
+    userTaskResult: DataModels.UserTasks.UserTaskResult,
+  ): Promise<void> {
+    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
+
+    const urlRestPart = restSettings.paths.finishUserTask
+      .replace(restSettings.params.processInstanceId, processInstanceId)
+      .replace(restSettings.params.correlationId, correlationId)
+      .replace(restSettings.params.userTaskInstanceId, userTaskInstanceId);
+
+    const url = this.buildUrl(urlRestPart);
+
+    await this.httpClient.post<DataModels.UserTasks.UserTaskResult, void>(url, userTaskResult, requestAuthHeaders);
   }
 
   private createRequestAuthHeaders(identity: IIdentity): IRequestOptions {
@@ -840,8 +931,16 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     return requestAuthHeaders;
   }
 
-  private applyBaseUrl(url: string): string {
-    return `${this.baseUrl}${url}`;
+  private buildUrl(url: string, offset: number = 0, limit: number = 0): string {
+    let finalUrl = `${this.baseUrl}${url}`;
+
+    if (finalUrl.indexOf('?') > 0) {
+      finalUrl = `${finalUrl}&offset=${offset}&limit=${limit}`;
+    } else {
+      finalUrl = `${finalUrl}?offset=${offset}&limit=${limit}`;
+    }
+
+    return finalUrl;
   }
 
   private createSocketIoSubscription<TCallback extends Function>(

--- a/typescript/src/accessors/internal_accessor.ts
+++ b/typescript/src/accessors/internal_accessor.ts
@@ -37,8 +37,12 @@ export class InternalAccessor implements IConsumerApiAccessor {
   }
 
   // Process models and instances
-  public async getProcessModels(identity: IIdentity): Promise<DataModels.ProcessModels.ProcessModelList> {
-    return this.processModelService.getProcessModels(identity);
+  public async getProcessModels(
+    identity: IIdentity,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.ProcessModels.ProcessModelList> {
+    return this.processModelService.getProcessModels(identity, offset, limit);
   }
 
   public async getProcessModelById(identity: IIdentity, processModelId: string): Promise<DataModels.ProcessModels.ProcessModel> {
@@ -57,7 +61,6 @@ export class InternalAccessor implements IConsumerApiAccessor {
     startEventId?: string,
     endEventId?: string,
   ): Promise<DataModels.ProcessModels.ProcessStartResponsePayload> {
-
     return this.processModelService.startProcessInstance(identity, processModelId, payload, startCallbackType, startEventId, endEventId);
   }
 
@@ -66,66 +69,61 @@ export class InternalAccessor implements IConsumerApiAccessor {
     correlationId: string,
     processModelId: string,
   ): Promise<Array<DataModels.CorrelationResult>> {
-
     return this.processModelService.getProcessResultForCorrelation(identity, correlationId, processModelId);
   }
 
-  public async getProcessInstancesByIdentity(identity: IIdentity): Promise<Array<DataModels.ProcessInstance>> {
-    return this.processModelService.getProcessInstancesByIdentity(identity);
-  }
-
-  // Events
-  public async getEventsForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.Events.EventList> {
-    return this.eventService.getEventsForProcessModel(identity, processModelId);
-  }
-
-  public async getEventsForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.Events.EventList> {
-    return this.eventService.getEventsForCorrelation(identity, correlationId);
-  }
-
-  public async getEventsForProcessModelInCorrelation(
+  public async getProcessInstancesByIdentity(
     identity: IIdentity,
-    processModelId: string,
-    correlationId: string,
-  ): Promise<DataModels.Events.EventList> {
-
-    return this.eventService.getEventsForProcessModelInCorrelation(identity, processModelId, correlationId);
-  }
-
-  public async triggerMessageEvent(identity: IIdentity, messageName: string, payload?: DataModels.Events.EventTriggerPayload): Promise<void> {
-    return this.eventService.triggerMessageEvent(identity, messageName, payload);
-  }
-
-  public async triggerSignalEvent(identity: IIdentity, signalName: string, payload?: DataModels.Events.EventTriggerPayload): Promise<void> {
-    return this.eventService.triggerSignalEvent(identity, signalName, payload);
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<Array<DataModels.ProcessInstance>> {
+    return this.processModelService.getProcessInstancesByIdentity(identity, offset, limit);
   }
 
   // Empty Activities
-  public async getEmptyActivitiesForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.EmptyActivities.EmptyActivityList> {
-    return this.emptyActivityService.getEmptyActivitiesForProcessModel(identity, processModelId);
+  public async getEmptyActivitiesForProcessModel(
+    identity: IIdentity,
+    processModelId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.EmptyActivities.EmptyActivityList> {
+    return this.emptyActivityService.getEmptyActivitiesForProcessModel(identity, processModelId, offset, limit);
   }
 
   public async getEmptyActivitiesForProcessInstance(
     identity: IIdentity,
     processInstanceId: string,
+    offset: number = 0,
+    limit: number = 0,
   ): Promise<DataModels.EmptyActivities.EmptyActivityList> {
-    return this.emptyActivityService.getEmptyActivitiesForProcessInstance(identity, processInstanceId);
+    return this.emptyActivityService.getEmptyActivitiesForProcessInstance(identity, processInstanceId, offset, limit);
   }
 
-  public async getEmptyActivitiesForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.EmptyActivities.EmptyActivityList> {
-    return this.emptyActivityService.getEmptyActivitiesForCorrelation(identity, correlationId);
+  public async getEmptyActivitiesForCorrelation(
+    identity: IIdentity,
+    correlationId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.EmptyActivities.EmptyActivityList> {
+    return this.emptyActivityService.getEmptyActivitiesForCorrelation(identity, correlationId, offset, limit);
   }
 
   public async getEmptyActivitiesForProcessModelInCorrelation(
     identity: IIdentity,
     processModelId: string,
     correlationId: string,
+    offset: number = 0,
+    limit: number = 0,
   ): Promise<DataModels.EmptyActivities.EmptyActivityList> {
-    return this.emptyActivityService.getEmptyActivitiesForProcessModelInCorrelation(identity, processModelId, correlationId);
+    return this.emptyActivityService.getEmptyActivitiesForProcessModelInCorrelation(identity, processModelId, correlationId, offset, limit);
   }
 
-  public async getWaitingEmptyActivitiesByIdentity(identity: IIdentity): Promise<DataModels.EmptyActivities.EmptyActivityList> {
-    return this.emptyActivityService.getWaitingEmptyActivitiesByIdentity(identity);
+  public async getWaitingEmptyActivitiesByIdentity(
+    identity: IIdentity,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.EmptyActivities.EmptyActivityList> {
+    return this.emptyActivityService.getWaitingEmptyActivitiesByIdentity(identity, offset, limit);
   }
 
   public async finishEmptyActivity(
@@ -137,7 +135,44 @@ export class InternalAccessor implements IConsumerApiAccessor {
     return this.emptyActivityService.finishEmptyActivity(identity, processInstanceId, correlationId, emptyActivityInstanceId);
   }
 
-  // ExternalTasks
+  // Events
+  public async getEventsForProcessModel(
+    identity: IIdentity,
+    processModelId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.Events.EventList> {
+    return this.eventService.getEventsForProcessModel(identity, processModelId, offset, limit);
+  }
+
+  public async getEventsForCorrelation(
+    identity: IIdentity,
+    correlationId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.Events.EventList> {
+    return this.eventService.getEventsForCorrelation(identity, correlationId, offset, limit);
+  }
+
+  public async getEventsForProcessModelInCorrelation(
+    identity: IIdentity,
+    processModelId: string,
+    correlationId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.Events.EventList> {
+    return this.eventService.getEventsForProcessModelInCorrelation(identity, processModelId, correlationId, offset, limit);
+  }
+
+  public async triggerMessageEvent(identity: IIdentity, messageName: string, payload?: DataModels.Events.EventTriggerPayload): Promise<void> {
+    return this.eventService.triggerMessageEvent(identity, messageName, payload);
+  }
+
+  public async triggerSignalEvent(identity: IIdentity, signalName: string, payload?: DataModels.Events.EventTriggerPayload): Promise<void> {
+    return this.eventService.triggerSignalEvent(identity, signalName, payload);
+  }
+
+  // ExternalTask
   public async fetchAndLockExternalTasks<TPayloadType>(
     identity: IIdentity,
     workerId: string,
@@ -169,39 +204,54 @@ export class InternalAccessor implements IConsumerApiAccessor {
     return this.externalTaskService.handleServiceError(identity, workerId, externalTaskId, errorMessage, errorDetails);
   }
 
-  public async finishExternalTask<TResultType>(
-    identity: IIdentity,
-    workerId: string,
-    externalTaskId: string,
-    payload: TResultType,
-  ): Promise<void> {
-    return this.externalTaskService.finishExternalTask(identity, workerId, externalTaskId, payload);
+  public async finishExternalTask<TResultType>(identity: IIdentity, workerId: string, externalTaskId: string, payload: TResultType): Promise<void> {
+    return this.externalTaskService.finishExternalTask<TResultType>(identity, workerId, externalTaskId, payload);
   }
 
   // ManualTasks
-  public async getManualTasksForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
-    return this.manualTaskService.getManualTasksForProcessModel(identity, processModelId);
+  public async getManualTasksForProcessModel(
+    identity: IIdentity,
+    processModelId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.ManualTasks.ManualTaskList> {
+    return this.manualTaskService.getManualTasksForProcessModel(identity, processModelId, offset, limit);
   }
 
-  public async getManualTasksForProcessInstance(identity: IIdentity, processInstanceId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
-    return this.manualTaskService.getManualTasksForProcessInstance(identity, processInstanceId);
+  public async getManualTasksForProcessInstance(
+    identity: IIdentity,
+    processInstanceId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.ManualTasks.ManualTaskList> {
+    return this.manualTaskService.getManualTasksForProcessInstance(identity, processInstanceId, offset, limit);
   }
 
-  public async getManualTasksForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
-    return this.manualTaskService.getManualTasksForCorrelation(identity, correlationId);
+  public async getManualTasksForCorrelation(
+    identity: IIdentity,
+    correlationId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.ManualTasks.ManualTaskList> {
+    return this.manualTaskService.getManualTasksForCorrelation(identity, correlationId, offset, limit);
   }
 
   public async getManualTasksForProcessModelInCorrelation(
     identity: IIdentity,
     processModelId: string,
     correlationId: string,
+    offset: number = 0,
+    limit: number = 0,
   ): Promise<DataModels.ManualTasks.ManualTaskList> {
-
-    return this.manualTaskService.getManualTasksForProcessModelInCorrelation(identity, processModelId, correlationId);
+    return this.manualTaskService.getManualTasksForProcessModelInCorrelation(identity, processModelId, correlationId, offset, limit);
   }
 
-  public async getWaitingManualTasksByIdentity(identity: IIdentity): Promise<DataModels.ManualTasks.ManualTaskList> {
-    return this.manualTaskService.getWaitingManualTasksByIdentity(identity);
+  public async getWaitingManualTasksByIdentity(
+    identity: IIdentity,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.ManualTasks.ManualTaskList> {
+    return this.manualTaskService.getWaitingManualTasksByIdentity(identity, offset, limit);
   }
 
   public async finishManualTask(
@@ -210,34 +260,53 @@ export class InternalAccessor implements IConsumerApiAccessor {
     correlationId: string,
     manualTaskInstanceId: string,
   ): Promise<void> {
-
     return this.manualTaskService.finishManualTask(identity, processInstanceId, correlationId, manualTaskInstanceId);
   }
 
   // UserTasks
-  public async getUserTasksForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.UserTasks.UserTaskList> {
-    return this.userTaskService.getUserTasksForProcessModel(identity, processModelId);
+  public async getUserTasksForProcessModel(
+    identity: IIdentity,
+    processModelId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.UserTasks.UserTaskList> {
+    return this.userTaskService.getUserTasksForProcessModel(identity, processModelId, offset, limit);
   }
 
-  public async getUserTasksForProcessInstance(identity: IIdentity, processInstanceId: string): Promise<DataModels.UserTasks.UserTaskList> {
-    return this.userTaskService.getUserTasksForProcessInstance(identity, processInstanceId);
+  public async getUserTasksForProcessInstance(
+    identity: IIdentity,
+    processInstanceId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.UserTasks.UserTaskList> {
+    return this.userTaskService.getUserTasksForProcessInstance(identity, processInstanceId, offset, limit);
   }
 
-  public async getUserTasksForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.UserTasks.UserTaskList> {
-    return this.userTaskService.getUserTasksForCorrelation(identity, correlationId);
+  public async getUserTasksForCorrelation(
+    identity: IIdentity,
+    correlationId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.UserTasks.UserTaskList> {
+    return this.userTaskService.getUserTasksForCorrelation(identity, correlationId, offset, limit);
   }
 
   public async getUserTasksForProcessModelInCorrelation(
     identity: IIdentity,
     processModelId: string,
     correlationId: string,
+    offset: number = 0,
+    limit: number = 0,
   ): Promise<DataModels.UserTasks.UserTaskList> {
-
-    return this.userTaskService.getUserTasksForProcessModelInCorrelation(identity, processModelId, correlationId);
+    return this.userTaskService.getUserTasksForProcessModelInCorrelation(identity, processModelId, correlationId, offset, limit);
   }
 
-  public async getWaitingUserTasksByIdentity(identity: IIdentity): Promise<DataModels.UserTasks.UserTaskList> {
-    return this.userTaskService.getWaitingUserTasksByIdentity(identity);
+  public async getWaitingUserTasksByIdentity(
+    identity: IIdentity,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.UserTasks.UserTaskList> {
+    return this.userTaskService.getWaitingUserTasksByIdentity(identity, offset, limit);
   }
 
   public async finishUserTask(
@@ -247,7 +316,6 @@ export class InternalAccessor implements IConsumerApiAccessor {
     userTaskInstanceId: string,
     userTaskResult: DataModels.UserTasks.UserTaskResult,
   ): Promise<void> {
-
     return this.userTaskService.finishUserTask(identity, processInstanceId, correlationId, userTaskInstanceId, userTaskResult);
   }
 

--- a/typescript/src/consumer_api_client.ts
+++ b/typescript/src/consumer_api_client.ts
@@ -288,10 +288,14 @@ export class ConsumerApiClient implements IConsumerApiClient {
   }
 
   // Process models and instances
-  public async getProcessModels(identity: IIdentity): Promise<DataModels.ProcessModels.ProcessModelList> {
+  public async getProcessModels(
+    identity: IIdentity,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.ProcessModels.ProcessModelList> {
     this.ensureIsAuthorized(identity);
 
-    return this.consumerApiAccessor.getProcessModels(identity);
+    return this.consumerApiAccessor.getProcessModels(identity, offset, limit);
   }
 
   public async getProcessModelById(identity: IIdentity, processModelId: string): Promise<DataModels.ProcessModels.ProcessModel> {
@@ -346,33 +350,116 @@ export class ConsumerApiClient implements IConsumerApiClient {
     return this.consumerApiAccessor.getProcessResultForCorrelation(identity, correlationId, processModelId);
   }
 
-  public async getProcessInstancesByIdentity(identity: IIdentity): Promise<Array<DataModels.ProcessInstance>> {
+  public async getProcessInstancesByIdentity(
+    identity: IIdentity,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<Array<DataModels.ProcessInstance>> {
     this.ensureIsAuthorized(identity);
 
-    return this.consumerApiAccessor.getProcessInstancesByIdentity(identity);
+    return this.consumerApiAccessor.getProcessInstancesByIdentity(identity, offset, limit);
+  }
+
+  // Empty Activities
+  public async getEmptyActivitiesForProcessModel(
+    identity: IIdentity,
+    processModelId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.EmptyActivities.EmptyActivityList> {
+    this.ensureIsAuthorized(identity);
+
+    return this.consumerApiAccessor.getEmptyActivitiesForProcessModel(identity, processModelId, offset, limit);
+  }
+
+  public async getEmptyActivitiesForProcessInstance(
+    identity: IIdentity,
+    processInstanceId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.EmptyActivities.EmptyActivityList> {
+    this.ensureIsAuthorized(identity);
+
+    return this.consumerApiAccessor.getEmptyActivitiesForProcessInstance(identity, processInstanceId, offset, limit);
+  }
+
+  public async getEmptyActivitiesForCorrelation(
+    identity: IIdentity,
+    correlationId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.EmptyActivities.EmptyActivityList> {
+    this.ensureIsAuthorized(identity);
+
+    return this.consumerApiAccessor.getEmptyActivitiesForCorrelation(identity, correlationId, offset, limit);
+  }
+
+  public async getEmptyActivitiesForProcessModelInCorrelation(
+    identity: IIdentity,
+    processModelId: string,
+    correlationId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.EmptyActivities.EmptyActivityList> {
+    this.ensureIsAuthorized(identity);
+
+    return this.consumerApiAccessor.getEmptyActivitiesForProcessModelInCorrelation(identity, processModelId, correlationId, offset, limit);
+  }
+
+  public async getWaitingEmptyActivitiesByIdentity(
+    identity: IIdentity,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.EmptyActivities.EmptyActivityList> {
+    this.ensureIsAuthorized(identity);
+
+    return this.consumerApiAccessor.getWaitingEmptyActivitiesByIdentity(identity, offset, limit);
+  }
+
+  public async finishEmptyActivity(
+    identity: IIdentity,
+    processInstanceId: string,
+    correlationId: string,
+    emptyActivityInstanceId: string,
+  ): Promise<void> {
+    this.ensureIsAuthorized(identity);
+
+    return this.consumerApiAccessor.finishEmptyActivity(identity, processInstanceId, correlationId, emptyActivityInstanceId);
   }
 
   // Events
-  public async getEventsForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.Events.EventList> {
+  public async getEventsForProcessModel(
+    identity: IIdentity,
+    processModelId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.Events.EventList> {
     this.ensureIsAuthorized(identity);
 
-    return this.consumerApiAccessor.getEventsForProcessModel(identity, processModelId);
+    return this.consumerApiAccessor.getEventsForProcessModel(identity, processModelId, offset, limit);
   }
 
-  public async getEventsForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.Events.EventList> {
+  public async getEventsForCorrelation(
+    identity: IIdentity,
+    correlationId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.Events.EventList> {
     this.ensureIsAuthorized(identity);
 
-    return this.consumerApiAccessor.getEventsForCorrelation(identity, correlationId);
+    return this.consumerApiAccessor.getEventsForCorrelation(identity, correlationId, offset, limit);
   }
 
   public async getEventsForProcessModelInCorrelation(
     identity: IIdentity,
     processModelId: string,
     correlationId: string,
+    offset: number = 0,
+    limit: number = 0,
   ): Promise<DataModels.Events.EventList> {
     this.ensureIsAuthorized(identity);
 
-    return this.consumerApiAccessor.getEventsForProcessModelInCorrelation(identity, processModelId, correlationId);
+    return this.consumerApiAccessor.getEventsForProcessModelInCorrelation(identity, processModelId, correlationId, offset, limit);
   }
 
   public async triggerMessageEvent(identity: IIdentity, messageName: string, payload?: DataModels.Events.EventTriggerPayload): Promise<void> {
@@ -385,55 +472,6 @@ export class ConsumerApiClient implements IConsumerApiClient {
     this.ensureIsAuthorized(identity);
 
     return this.consumerApiAccessor.triggerSignalEvent(identity, signalName, payload);
-  }
-
-  // Empty Activities
-  public async getEmptyActivitiesForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.EmptyActivities.EmptyActivityList> {
-    this.ensureIsAuthorized(identity);
-
-    return this.consumerApiAccessor.getEmptyActivitiesForProcessModel(identity, processModelId);
-  }
-
-  public async getEmptyActivitiesForProcessInstance(
-    identity: IIdentity,
-    processInstanceId: string,
-  ): Promise<DataModels.EmptyActivities.EmptyActivityList> {
-    this.ensureIsAuthorized(identity);
-
-    return this.consumerApiAccessor.getEmptyActivitiesForProcessInstance(identity, processInstanceId);
-  }
-
-  public async getEmptyActivitiesForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.EmptyActivities.EmptyActivityList> {
-    this.ensureIsAuthorized(identity);
-
-    return this.consumerApiAccessor.getEmptyActivitiesForCorrelation(identity, correlationId);
-  }
-
-  public async getEmptyActivitiesForProcessModelInCorrelation(
-    identity: IIdentity,
-    processModelId: string,
-    correlationId: string,
-  ): Promise<DataModels.EmptyActivities.EmptyActivityList> {
-    this.ensureIsAuthorized(identity);
-
-    return this.consumerApiAccessor.getEmptyActivitiesForProcessModelInCorrelation(identity, processModelId, correlationId);
-  }
-
-  public async getWaitingEmptyActivitiesByIdentity(identity: IIdentity): Promise<DataModels.EmptyActivities.EmptyActivityList> {
-    this.ensureIsAuthorized(identity);
-
-    return this.consumerApiAccessor.getWaitingEmptyActivitiesByIdentity(identity);
-  }
-
-  public async finishEmptyActivity(
-    identity: IIdentity,
-    processInstanceId: string,
-    correlationId: string,
-    emptyActivityInstanceId: string,
-  ): Promise<void> {
-    this.ensureIsAuthorized(identity);
-
-    return this.consumerApiAccessor.finishEmptyActivity(identity, processInstanceId, correlationId, emptyActivityInstanceId);
   }
 
   // ExternalTask
@@ -482,39 +520,127 @@ export class ConsumerApiClient implements IConsumerApiClient {
     return this.consumerApiAccessor.finishExternalTask<TResultType>(identity, workerId, externalTaskId, payload);
   }
 
+  // ManualTasks
+  public async getManualTasksForProcessModel(
+    identity: IIdentity,
+    processModelId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.ManualTasks.ManualTaskList> {
+    this.ensureIsAuthorized(identity);
+
+    return this.consumerApiAccessor.getManualTasksForProcessModel(identity, processModelId, offset, limit);
+  }
+
+  public async getManualTasksForProcessInstance(
+    identity: IIdentity,
+    processInstanceId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.ManualTasks.ManualTaskList> {
+    this.ensureIsAuthorized(identity);
+
+    return this.consumerApiAccessor.getManualTasksForProcessInstance(identity, processInstanceId, offset, limit);
+  }
+
+  public async getManualTasksForCorrelation(
+    identity: IIdentity,
+    correlationId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.ManualTasks.ManualTaskList> {
+    this.ensureIsAuthorized(identity);
+
+    return this.consumerApiAccessor.getManualTasksForCorrelation(identity, correlationId, offset, limit);
+  }
+
+  public async getManualTasksForProcessModelInCorrelation(
+    identity: IIdentity,
+    processModelId: string,
+    correlationId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.ManualTasks.ManualTaskList> {
+    this.ensureIsAuthorized(identity);
+
+    return this.consumerApiAccessor.getManualTasksForProcessModelInCorrelation(identity, processModelId, correlationId, offset, limit);
+  }
+
+  public async getWaitingManualTasksByIdentity(
+    identity: IIdentity,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.ManualTasks.ManualTaskList> {
+    this.ensureIsAuthorized(identity);
+
+    return this.consumerApiAccessor.getWaitingManualTasksByIdentity(identity, offset, limit);
+  }
+
+  public async finishManualTask(
+    identity: IIdentity,
+    processInstanceId: string,
+    correlationId: string,
+    manualTaskInstanceId: string,
+  ): Promise<void> {
+    this.ensureIsAuthorized(identity);
+
+    return this.consumerApiAccessor.finishManualTask(identity, processInstanceId, correlationId, manualTaskInstanceId);
+  }
+
   // UserTasks
-  public async getUserTasksForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.UserTasks.UserTaskList> {
+  public async getUserTasksForProcessModel(
+    identity: IIdentity,
+    processModelId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.UserTasks.UserTaskList> {
     this.ensureIsAuthorized(identity);
 
-    return this.consumerApiAccessor.getUserTasksForProcessModel(identity, processModelId);
+    return this.consumerApiAccessor.getUserTasksForProcessModel(identity, processModelId, offset, limit);
   }
 
-  public async getUserTasksForProcessInstance(identity: IIdentity, processInstanceId: string): Promise<DataModels.UserTasks.UserTaskList> {
+  public async getUserTasksForProcessInstance(
+    identity: IIdentity,
+    processInstanceId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.UserTasks.UserTaskList> {
     this.ensureIsAuthorized(identity);
 
-    return this.consumerApiAccessor.getUserTasksForProcessInstance(identity, processInstanceId);
+    return this.consumerApiAccessor.getUserTasksForProcessInstance(identity, processInstanceId, offset, limit);
   }
 
-  public async getUserTasksForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.UserTasks.UserTaskList> {
+  public async getUserTasksForCorrelation(
+    identity: IIdentity,
+    correlationId: string,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.UserTasks.UserTaskList> {
     this.ensureIsAuthorized(identity);
 
-    return this.consumerApiAccessor.getUserTasksForCorrelation(identity, correlationId);
+    return this.consumerApiAccessor.getUserTasksForCorrelation(identity, correlationId, offset, limit);
   }
 
   public async getUserTasksForProcessModelInCorrelation(
     identity: IIdentity,
     processModelId: string,
     correlationId: string,
+    offset: number = 0,
+    limit: number = 0,
   ): Promise<DataModels.UserTasks.UserTaskList> {
     this.ensureIsAuthorized(identity);
 
-    return this.consumerApiAccessor.getUserTasksForProcessModelInCorrelation(identity, processModelId, correlationId);
+    return this.consumerApiAccessor.getUserTasksForProcessModelInCorrelation(identity, processModelId, correlationId, offset, limit);
   }
 
-  public async getWaitingUserTasksByIdentity(identity: IIdentity): Promise<DataModels.UserTasks.UserTaskList> {
+  public async getWaitingUserTasksByIdentity(
+    identity: IIdentity,
+    offset: number = 0,
+    limit: number = 0,
+  ): Promise<DataModels.UserTasks.UserTaskList> {
     this.ensureIsAuthorized(identity);
 
-    return this.consumerApiAccessor.getWaitingUserTasksByIdentity(identity);
+    return this.consumerApiAccessor.getWaitingUserTasksByIdentity(identity, offset, limit);
   }
 
   public async finishUserTask(
@@ -527,52 +653,6 @@ export class ConsumerApiClient implements IConsumerApiClient {
     this.ensureIsAuthorized(identity);
 
     return this.consumerApiAccessor.finishUserTask(identity, processInstanceId, correlationId, userTaskInstanceId, userTaskResult);
-  }
-
-  // ManualTasks
-  public async getManualTasksForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
-    this.ensureIsAuthorized(identity);
-
-    return this.consumerApiAccessor.getManualTasksForProcessModel(identity, processModelId);
-  }
-
-  public async getManualTasksForProcessInstance(identity: IIdentity, processInstanceId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
-    this.ensureIsAuthorized(identity);
-
-    return this.consumerApiAccessor.getManualTasksForProcessInstance(identity, processInstanceId);
-  }
-
-  public async getManualTasksForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
-    this.ensureIsAuthorized(identity);
-
-    return this.consumerApiAccessor.getManualTasksForCorrelation(identity, correlationId);
-  }
-
-  public async getManualTasksForProcessModelInCorrelation(
-    identity: IIdentity,
-    processModelId: string,
-    correlationId: string,
-  ): Promise<DataModels.ManualTasks.ManualTaskList> {
-    this.ensureIsAuthorized(identity);
-
-    return this.consumerApiAccessor.getManualTasksForProcessModelInCorrelation(identity, processModelId, correlationId);
-  }
-
-  public async getWaitingManualTasksByIdentity(identity: IIdentity): Promise<DataModels.ManualTasks.ManualTaskList> {
-    this.ensureIsAuthorized(identity);
-
-    return this.consumerApiAccessor.getWaitingManualTasksByIdentity(identity);
-  }
-
-  public async finishManualTask(
-    identity: IIdentity,
-    processInstanceId: string,
-    correlationId: string,
-    manualTaskInstanceId: string,
-  ): Promise<void> {
-    this.ensureIsAuthorized(identity);
-
-    return this.consumerApiAccessor.finishManualTask(identity, processInstanceId, correlationId, manualTaskInstanceId);
   }
 
   private ensureIsAuthorized(identity: IIdentity): void {


### PR DESCRIPTION
## Changes

1. Add `offset` and `limit` to each query that returns a list of values (.NET Client and .ts client)
2. Order the UseCases of the .ts client
3. Unify variable naming in the .ts ExternalAccessor

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/379

PR: #59