### PR TITLE
Update Jenkinsfile and ci_tools

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,6 +67,12 @@ pipeline {
         dir('typescript') {
           sh('node --version')
           sh('node ./node_modules/.bin/ci_tools prepare-version --allow-dirty-workdir');
+
+          withCredentials([
+            usernamePassword(credentialsId: 'process-engine-ci_github-token', passwordVariable: 'GH_TOKEN', usernameVariable: 'GH_USER')
+          ]) {
+            sh('node ./node_modules/.bin/ci_tools commit-and-tag-version --only-on-primary-branches')
+          }
         }
       }
     }
@@ -94,7 +100,6 @@ pipeline {
               withCredentials([
                 usernamePassword(credentialsId: 'process-engine-ci_github-token', passwordVariable: 'GH_TOKEN', usernameVariable: 'GH_USER')
               ]) {
-                sh('node ./node_modules/.bin/ci_tools commit-and-tag-version --only-on-primary-branches')
                 sh('node ./node_modules/.bin/ci_tools update-github-release --only-on-primary-branches --use-title-and-text-from-git-tag');
               }
             }

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",
-    "@process-engine/ci_tools": "^2.0.0",
+    "@process-engine/ci_tools": "^2.1.0",
     "@types/express": "^4.16.0",
     "@types/node": "^10.12.2",
     "@types/socket.io": "^2.1.0",


### PR DESCRIPTION
@ElRaptorus Der Schritt 

```bash
ci_tools commit-and-tag-version --only-on-primary-branches
```

sollte möglichst getrennt vom Publishen stattfinden, da es hier ja nicht nur um das Taggen zum Zwecke des GitHub Releases geht, sondern - wie besprochen - die Tags auch die *single source of truth* für die `ci_tools` darstellen (und ich persönlich es so auch leichter zu greifen finde, wenn ich weiß, dass alles bis Schritt "Set package version" sozusagen "im Tag" ist).

Wenn wir diesen PR auf `develop` mergen, müsste er anschließend `v6.1.0-alpha.2` taggen und veröffentlichen. Mal gucken, ob das klappt :+1: