### PR TITLE
 ♻️ Make ExternalTaskWorker immutable

### DIFF
--- a/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
+++ b/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
@@ -1,28 +1,28 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.3.0</Version>
-    <RootNamespace>ProcessEngine.ConsumerAPI.Client</RootNamespace>
-    <AssemblyName>ProcessEngine.ConsumerAPI.Client</AssemblyName>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Authors>Christian Werner;Sebastian Meier;</Authors>
-    <Company>5Minds IT-Solutions GmbH &amp; Co. KG</Company>
-    <Description />
-    <Copyright>Copyright © 5Minds IT-Solutions GmbH &amp; Co. KG 2018</Copyright>
-    <PackageProjectUrl>https://github.com/process-engine/consumer_api_client</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/process-engine/consumer_api_client</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageTags>ConsumerAPI;5Minds</PackageTags>
-    <PackageLicenseUrl />
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <Version>1.3.0</Version>
+        <RootNamespace>ProcessEngine.ConsumerAPI.Client</RootNamespace>
+        <AssemblyName>ProcessEngine.ConsumerAPI.Client</AssemblyName>
+        <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+        <Authors>Christian Werner;Sebastian Meier;</Authors>
+        <Company>5Minds IT-Solutions GmbH &amp; Co. KG</Company>
+        <Description />
+        <Copyright>Copyright © 5Minds IT-Solutions GmbH &amp; Co. KG 2018</Copyright>
+        <PackageProjectUrl>https://github.com/process-engine/consumer_api_client</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/process-engine/consumer_api_client</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PackageTags>ConsumerAPI;5Minds</PackageTags>
+        <PackageLicenseUrl />
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.1.0-develop" />
-    <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
+        <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+        <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.1.0-feature-make-external-task-worker-immutable" />
+    </ItemGroup>
 
 
 

--- a/dotnet/tests/ProcessEngine.ConsumerAPI.Client.Tests.csproj
+++ b/dotnet/tests/ProcessEngine.ConsumerAPI.Client.Tests.csproj
@@ -1,40 +1,40 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.1.0-develop" />
-    <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\src\ProcessEngine.ConsumerAPI.Client.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Update="bpmn\test_consumer_api_correlation_result.bpmn">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="bpmn\test_consumer_api_emptyactivity.bpmn">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="bpmn\test_start_process.bpmn">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="bpmn\test_consumer_api_signal_event.bpmn">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="bpmn\test_consumer_api_message_event.bpmn">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="bpmn\test_consumer_api_manualtask.bpmn">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="bpmn\test_consumer_api_usertask.bpmn">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+    <PropertyGroup>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+        <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+        <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.1.0-feature-make-external-task-worker-immutable" />
+        <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+        <PackageReference Include="xunit" Version="2.4.0" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\src\ProcessEngine.ConsumerAPI.Client.csproj" />
+    </ItemGroup>
+    <ItemGroup>
+        <None Update="bpmn\test_consumer_api_correlation_result.bpmn">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+        <None Update="bpmn\test_consumer_api_emptyactivity.bpmn">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+        <None Update="bpmn\test_start_process.bpmn">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+        <None Update="bpmn\test_consumer_api_signal_event.bpmn">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+        <None Update="bpmn\test_consumer_api_message_event.bpmn">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+        <None Update="bpmn\test_consumer_api_manualtask.bpmn">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+        <None Update="bpmn\test_consumer_api_usertask.bpmn">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
 </Project>

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -31,7 +31,7 @@
     "@essential-projects/errors_ts": "^1.5.0",
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/consumer_api_contracts": "8.1.0-35fc9279-b29",
+    "@process-engine/consumer_api_contracts": "feature~make_external_task_worker_immutable",
     "async-middleware": "^1.2.1",
     "bluebird": "^3.5.3",
     "loggerhythm": "^3.0.3",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@essential-projects/errors_ts": "^1.5.0",
     "@essential-projects/http_contracts": "^2.4.0",
+    "@essential-projects/http": "^2.4.0",
     "@essential-projects/iam_contracts": "^3.5.0",
     "@process-engine/consumer_api_contracts": "feature~make_external_task_worker_immutable",
     "async-middleware": "^1.2.1",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -32,7 +32,7 @@
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/http": "^2.4.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/consumer_api_contracts": "feature~make_external_task_worker_immutable",
+    "@process-engine/consumer_api_contracts": "8.1.0-c1903190-b30",
     "async-middleware": "^1.2.1",
     "bluebird": "^3.5.3",
     "loggerhythm": "^3.0.3",

--- a/typescript/src/external_task_worker.ts
+++ b/typescript/src/external_task_worker.ts
@@ -1,48 +1,86 @@
+/* eslint-disable @typescript-eslint/member-naming */
 import {Logger} from 'loggerhythm';
 import * as uuid from 'node-uuid';
 
+import {HttpClient} from '@essential-projects/http';
 import {IIdentity} from '@essential-projects/iam_contracts';
-
 import {
-  APIs,
   DataModels,
   HandleExternalTaskAction,
   IExternalTaskWorker,
 } from '@process-engine/consumer_api_contracts';
 
-const logger: Logger = Logger.createLogger('processengine:consumer_api:external_task_worker');
+import {ExternalAccessor} from './accessors/external_accessor';
+import {ConsumerApiClient} from './consumer_api_client';
 
-export class ExternalTaskWorker implements IExternalTaskWorker {
+const logger: Logger = Logger.createLogger('processengine:consumer_api_client:external_task_worker');
 
-  // eslint-disable-next-line @typescript-eslint/member-naming
+export class ExternalTaskWorker<TExternalTaskPayload, TResultPayload> implements IExternalTaskWorker {
+
   private readonly _workerId = uuid.v4();
   private readonly lockDuration = 30000;
-  private readonly externalTaskService: APIs.IExternalTaskConsumerApi;
+  private readonly processEngineUrl: string;
+  private readonly identity: IIdentity;
+  private readonly topic: string;
+  private readonly maxTasks: number;
+  private readonly longpollingTimeout: number;
+  private readonly processingFunction: HandleExternalTaskAction<TExternalTaskPayload, TResultPayload>;
 
-  constructor(externalTaskService: APIs.IExternalTaskConsumerApi) {
-    this.externalTaskService = externalTaskService;
+  private _pollingActive: boolean = false;
+  private consumerApiClient: ConsumerApiClient;
+
+  constructor(
+    processEngineUrl: string,
+    identity: IIdentity,
+    topic: string,
+    maxTasks: number,
+    longpollingTimeout: number,
+    processingFunction: HandleExternalTaskAction<TExternalTaskPayload, TResultPayload>,
+  ) {
+    this.processEngineUrl = processEngineUrl;
+    this.identity = identity;
+    this.topic = topic;
+    this.maxTasks = maxTasks;
+    this.longpollingTimeout = longpollingTimeout;
+    this.processingFunction = processingFunction;
+
+    this.initialize();
   }
 
   public get workerId(): string {
     return this._workerId;
   }
 
-  public async waitForAndHandle<TPayload>(
-    identity: IIdentity,
-    topic: string,
-    maxTasks: number,
-    longpollingTimeout: number,
-    handleAction: HandleExternalTaskAction<TPayload>,
-  ): Promise<void> {
+  public get pollingIsActive(): boolean {
+    return this._pollingActive;
+  }
 
-    const keepPolling = true;
-    while (keepPolling) {
+  public start(): void {
+    this._pollingActive = true;
+    this.processExternalTasks();
+  }
 
-      const externalTasks = await this.fetchAndLockExternalTasks<TPayload>(
-        identity,
-        topic,
-        maxTasks,
-        longpollingTimeout,
+  public stop(): void {
+    this._pollingActive = false;
+  }
+
+  private initialize(): void {
+    const httpClient = new HttpClient();
+    httpClient.config = {url: this.processEngineUrl};
+
+    const externalAccessor = new ExternalAccessor(httpClient);
+    this.consumerApiClient = new ConsumerApiClient(externalAccessor);
+  }
+
+  private async processExternalTasks(): Promise<void> {
+
+    while (this.pollingIsActive) {
+
+      const externalTasks = await this.fetchAndLockExternalTasks(
+        this.identity,
+        this.topic,
+        this.maxTasks,
+        this.longpollingTimeout,
       );
 
       if (externalTasks.length === 0) {
@@ -53,24 +91,24 @@ export class ExternalTaskWorker implements IExternalTaskWorker {
       const executeTaskPromises: Array<Promise<void>> = [];
 
       for (const externalTask of externalTasks) {
-        executeTaskPromises.push(this.executeExternalTask(identity, externalTask, handleAction));
+        executeTaskPromises.push(this.executeExternalTask(this.identity, externalTask));
       }
 
       await Promise.all(executeTaskPromises);
     }
   }
 
-  private async fetchAndLockExternalTasks<TPayload>(
+  private async fetchAndLockExternalTasks(
     identity: IIdentity,
     topic: string,
     maxTasks: number,
     longpollingTimeout: number,
-  ): Promise<Array<DataModels.ExternalTask.ExternalTask<TPayload>>> {
+  ): Promise<Array<DataModels.ExternalTask.ExternalTask<TExternalTaskPayload>>> {
 
     try {
       return await this
-        .externalTaskService
-        .fetchAndLockExternalTasks<TPayload>(identity, this.workerId, topic, maxTasks, longpollingTimeout, this.lockDuration);
+        .consumerApiClient
+        .fetchAndLockExternalTasks<TExternalTaskPayload>(identity, this.workerId, topic, maxTasks, longpollingTimeout, this.lockDuration);
     } catch (error) {
 
       logger.error(
@@ -85,31 +123,31 @@ export class ExternalTaskWorker implements IExternalTaskWorker {
     }
   }
 
-  private async executeExternalTask<TPayload>(
+  private async executeExternalTask(
     identity: IIdentity,
-    externalTask: DataModels.ExternalTask.ExternalTask<TPayload>,
-    handleAction: HandleExternalTaskAction<TPayload>,
+    externalTask: DataModels.ExternalTask.ExternalTask<TExternalTaskPayload>,
   ): Promise<void> {
 
     try {
       const lockExtensionBuffer = 5000;
 
       const interval =
-        setInterval(async (): Promise<void> => this.extendLocks<TPayload>(identity, externalTask), this.lockDuration - lockExtensionBuffer);
+        setInterval(async (): Promise<void> => this.extendLocks(identity, externalTask), this.lockDuration - lockExtensionBuffer);
 
-      const result = await handleAction(externalTask);
+      const result = await this.processingFunction(externalTask);
       clearInterval(interval);
 
       await this.processResult(identity, result, externalTask.id);
+
     } catch (error) {
       logger.error('Failed to execute ExternalTask!', error.message, error.stack);
-      await this.externalTaskService.handleServiceError(identity, this.workerId, externalTask.id, error.message, '');
+      await this.consumerApiClient.handleServiceError(identity, this.workerId, externalTask.id, error.message, '');
     }
   }
 
-  private async extendLocks<TPayload>(identity: IIdentity, externalTask: DataModels.ExternalTask.ExternalTask<TPayload>): Promise<void> {
+  private async extendLocks(identity: IIdentity, externalTask: DataModels.ExternalTask.ExternalTask<TExternalTaskPayload>): Promise<void> {
     try {
-      await this.externalTaskService.extendLock(identity, this.workerId, externalTask.id, this.lockDuration);
+      await this.consumerApiClient.extendLock(identity, this.workerId, externalTask.id, this.lockDuration);
     } catch (error) {
       // This can happen, if the lock-extension was performed after the task was already finished.
       // Since this isn't really an error, a warning suffices here.
@@ -120,21 +158,20 @@ export class ExternalTaskWorker implements IExternalTaskWorker {
   private async processResult(identity: IIdentity, result: DataModels.ExternalTask.ExternalTaskResultBase, externalTaskId: string): Promise<void> {
 
     if (result instanceof DataModels.ExternalTask.ExternalTaskBpmnError) {
-
       const bpmnError = result as DataModels.ExternalTask.ExternalTaskBpmnError;
-      await this.externalTaskService.handleBpmnError(identity, this.workerId, externalTaskId, bpmnError.errorCode);
+      await this.consumerApiClient.handleBpmnError(identity, this.workerId, externalTaskId, bpmnError.errorCode);
 
     } else if (result instanceof DataModels.ExternalTask.ExternalTaskServiceError) {
 
       const serviceError = result as DataModels.ExternalTask.ExternalTaskServiceError;
       await this
-        .externalTaskService
+        .consumerApiClient
         .handleServiceError(identity, this.workerId, externalTaskId, serviceError.errorMessage, serviceError.errorDetails);
 
     } else {
       await this
-        .externalTaskService
-        .finishExternalTask(identity, this.workerId, externalTaskId, (result as DataModels.ExternalTask.ExternalTaskSuccessResult<any>).result);
+        .consumerApiClient
+        .finishExternalTask(identity, this.workerId, externalTaskId, (result as DataModels.ExternalTask.ExternalTaskSuccessResult).result);
     }
   }
 


### PR DESCRIPTION
## Changes
 
1. Replace `waitForHandle` with `start/stop` pattern
2. Expect all essential parameters to be passed through the constructor
    - This will ensure that a single worker can only process a single topic; as it was meant to be
3. Expect two type parameters for worker class: 
    - `TExternalTaskPayload`: The type of the ExternalTask's payload
    - `TResultPayload`: The type of result's payload
4. Move all initialization of subdependencies (i.e. ConsumerApIClient and ExternalAccessor) into the ExternalTaskWorker.
    - The user now only needs to pass the url to the ProcessEngine. All initialization is handled by the worker itself now

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/410

PR: #62