### PR TITLE
✨ Add route for retrieving informtion about the host application

### DIFF
--- a/dotnet/src/ConsumerApiClientService.cs
+++ b/dotnet/src/ConsumerApiClientService.cs
@@ -31,6 +31,15 @@
             this.httpClient.Dispose();
         }
 
+        public async Task<ApplicationInfo> GetApplicationInfo(IIdentity identity)
+        {
+            var endpoint = RestSettings.Paths.GetApplicationInfo;
+
+            var result = await this.SendRequestAndExpectResult<ApplicationInfo>(identity, HttpMethod.Get, endpoint);
+
+            return result;
+        }
+
         public async Task<ProcessModelList> GetProcessModels(IIdentity identity, int offset = 0, int limit = 0)
         {
             var endpoint = RestSettings.Paths.ProcessModels;

--- a/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
+++ b/dotnet/src/ProcessEngine.ConsumerAPI.Client.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <Version>2.2.0</Version>
+        <Version>2.3.0</Version>
         <RootNamespace>ProcessEngine.ConsumerAPI.Client</RootNamespace>
         <AssemblyName>ProcessEngine.ConsumerAPI.Client</AssemblyName>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -21,7 +21,7 @@
     <ItemGroup>
         <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-        <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.3.1" />
+        <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="15.0.0-develop" />
     </ItemGroup>
 
 

--- a/dotnet/tests/ProcessEngine.ConsumerAPI.Client.Tests.csproj
+++ b/dotnet/tests/ProcessEngine.ConsumerAPI.Client.Tests.csproj
@@ -6,7 +6,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
         <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-        <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.3.1" />
+        <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="15.0.0-develop" />
         <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
         <PackageReference Include="xunit" Version="2.4.0" />

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/consumer_api_client",
-  "version": "6.3.0",
+  "version": "6.4.0",
   "description": "the api-client package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -32,7 +32,7 @@
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/http": "^2.4.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/consumer_api_contracts": "^9.2.0",
+    "@process-engine/consumer_api_contracts": "feature~add_info_route",
     "async-middleware": "^1.2.1",
     "bluebird": "^3.5.3",
     "loggerhythm": "^3.0.3",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -32,7 +32,7 @@
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/http": "^2.4.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/consumer_api_contracts": "feature~add_info_route",
+    "@process-engine/consumer_api_contracts": "10.0.0-alpha.2",
     "async-middleware": "^1.2.1",
     "bluebird": "^3.5.3",
     "loggerhythm": "^3.0.3",

--- a/typescript/src/accessors/external_accessor.ts
+++ b/typescript/src/accessors/external_accessor.ts
@@ -52,6 +52,18 @@ export class ExternalAccessor implements IConsumerApiAccessor, IConsumerSocketIo
     this.removeSocketForIdentity(identity);
   }
 
+  // Application Info
+
+  public async getApplicationInfo(identity: IIdentity): Promise<DataModels.ApplicationInfo> {
+    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
+
+    const url = this.buildUrl(restSettings.paths.getApplicationInfo);
+
+    const httpResponse = await this.httpClient.get<DataModels.ApplicationInfo>(url, requestAuthHeaders);
+
+    return httpResponse.result;
+  }
+
   // Notifications
 
   public async onActivityReached(

--- a/typescript/src/accessors/internal_accessor.ts
+++ b/typescript/src/accessors/internal_accessor.ts
@@ -10,16 +10,18 @@ import {
 
 export class InternalAccessor implements IConsumerApiAccessor {
 
-  private emptyActivityService: APIs.IEmptyActivityConsumerApi;
-  private eventService: APIs.IEventConsumerApi;
-  private externalTaskService: APIs.IExternalTaskConsumerApi;
-  private manualTaskService: APIs.IManualTaskConsumerApi;
-  private notificationService: APIs.INotificationConsumerApi;
-  private processModelService: APIs.IProcessModelConsumerApi;
-  private userTaskService: APIs.IUserTaskConsumerApi;
-  private flowNodeInstanceService: APIs.IFlowNodeInstanceConsumerApi;
+  private readonly applicationInfoService: APIs.IApplicationInfoConsumerApi;
+  private readonly emptyActivityService: APIs.IEmptyActivityConsumerApi;
+  private readonly eventService: APIs.IEventConsumerApi;
+  private readonly externalTaskService: APIs.IExternalTaskConsumerApi;
+  private readonly manualTaskService: APIs.IManualTaskConsumerApi;
+  private readonly notificationService: APIs.INotificationConsumerApi;
+  private readonly processModelService: APIs.IProcessModelConsumerApi;
+  private readonly userTaskService: APIs.IUserTaskConsumerApi;
+  private readonly flowNodeInstanceService: APIs.IFlowNodeInstanceConsumerApi;
 
   constructor(
+    applicationInfoService: APIs.IApplicationInfoConsumerApi,
     emptyActivityService: APIs.IEmptyActivityConsumerApi,
     eventService: APIs.IEventConsumerApi,
     externalTaskService: APIs.IExternalTaskConsumerApi,
@@ -29,6 +31,7 @@ export class InternalAccessor implements IConsumerApiAccessor {
     userTaskService: APIs.IUserTaskConsumerApi,
     flowNodeInstanceService: APIs.IFlowNodeInstanceConsumerApi,
   ) {
+    this.applicationInfoService = applicationInfoService;
     this.emptyActivityService = emptyActivityService;
     this.eventService = eventService;
     this.externalTaskService = externalTaskService;
@@ -37,6 +40,12 @@ export class InternalAccessor implements IConsumerApiAccessor {
     this.processModelService = processModelService;
     this.userTaskService = userTaskService;
     this.flowNodeInstanceService = flowNodeInstanceService;
+  }
+
+  // Application Info
+
+  public async getApplicationInfo(identity: IIdentity): Promise<DataModels.ApplicationInfo> {
+    return this.applicationInfoService.getApplicationInfo(identity);
   }
 
   // Process models and instances

--- a/typescript/src/consumer_api_client.ts
+++ b/typescript/src/consumer_api_client.ts
@@ -17,6 +17,10 @@ export class ConsumerApiClient implements IConsumerApiClient {
     this.consumerApiAccessor = consumerApiAccessor;
   }
 
+  public async getApplicationInfo(identity: IIdentity): Promise<DataModels.ApplicationInfo> {
+    return this.consumerApiAccessor.getApplicationInfo(identity);
+  }
+
   // Notifications
   public async onActivityReached(
     identity: IIdentity,


### PR DESCRIPTION
## Changes

Implement `getApplicationInfo` endpoint.

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/531

PR: #70

## How to test the changes

- Call the endpoint
- See that it returns information about the hosting application